### PR TITLE
Fixed check to determine if openvswitch module is loaded. [1/1]

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_install.rb
+++ b/chef/cookbooks/neutron/recipes/common_install.rb
@@ -78,7 +78,7 @@ if neutron[:neutron][:networking_plugin] == "openvswitch" or neutron[:neutron][:
     if node[:neutron][:platform][:ovs_pkgs].any?{|e|e == "openvswitch-datapath-dkms"} &&
         !File.exists?("/lib/modules/#{%x{uname -r}.strip}/updates/dkms/openvswitch.ko") &&
         File.directory?("/sys/module/openvswitch")
-      if IO.read("/sys/module/openvswitch").strip != "0"
+      if IO.read("/sys/module/openvswitch/refcnt").strip != "0"
         Chef::Log.error("Kernel openvswitch module already loaded and in use! Please reboot me!")
       else
         bash "Unload non-DKMS openvswitch module" do


### PR DESCRIPTION
The code has a clear bug in it where it is trying to read a directory
like a file, and is blowing up with:

Errno::EISDIR: Is a directory - /sys/module/openvswitch

This fix changes the directory path to read the refcnt file in the ovs
module directory, which I believe is what was intended.

 chef/cookbooks/neutron/recipes/common_install.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 18ae3a0917c54eed9dc08a3f7a0d6f209ca2406a

Crowbar-Release: roxy
