### PR TITLE
Set Verbose Logging by Default

### DIFF
--- a/chef/data_bags/crowbar/bc-template-neutron.json
+++ b/chef/data_bags/crowbar/bc-template-neutron.json
@@ -33,7 +33,7 @@
         "pip://pyudev"
       ],
       "debug": false,
-      "verbose": false,
+      "verbose": true,
       "dhcp_domain": "openstack.local",
       "networking_mode": "gre",
       "networking_plugin": "openvswitch",


### PR DESCRIPTION
This does not add that much more overhead to the actual logfiles,
but makes them tremendously more useful in case of unexpected
behavior happening.
