### PR TITLE
Fix syntax to be compatible with ruby 1.9

### DIFF
--- a/chef/cookbooks/neutron/providers/bridge.rb
+++ b/chef/cookbooks/neutron/providers/bridge.rb
@@ -5,7 +5,7 @@ action :create do
   when "linuxbridge"
     updated = false
     bridge_name = "brq" + ::Neutron.get_net_id_by_name(new_resource.network_name, new_resource.neutron_cmd)[0,11]
-    unless ::Nic.exists?(bridge_name):
+    unless ::Nic.exists?(bridge_name)
       ::Nic::Bridge.create(bridge_name)
       updated = true
     end


### PR DESCRIPTION
Colon is no longer allowed after if / unless in ruby 1.9.
