### PR TITLE
Make dhcp_agent.ini and metadata_agent.ini templates closer to upstream

### DIFF
--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -1,14 +1,77 @@
 # Managed by Crowbar.
 # Do not edit.
 [DEFAULT]
+# Show debugging output in log (sets DEBUG log level output)
 debug = <%= @debug ? "True" : "False" %>
+
+# The DHCP agent will resync its state with Neutron to recover from any
+# transient notification or rpc errors. The interval is number of
+# seconds between attempts.
 resync_interval = <%= @resync_interval %>
+
+# The DHCP agent requires an interface driver be set. Choose the one that best
+# matches your plugin.
 interface_driver = <%= @interface_driver %>
+
+# Example of interface_driver option for OVS based plugins(OVS, Ryu, NEC, NVP,
+# BigSwitch/Floodlight)
+# interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
+
+# Use veth for an OVS interface or not.
+# Support kernels with limited namespace support
+# (e.g. RHEL 6.5) so long as ovs_use_veth is set to True.
+# ovs_use_veth = False
+
+# Example of interface_driver option for LinuxBridge
+# interface_driver = neutron.agent.linux.interface.BridgeInterfaceDriver
+
+# The agent can use other DHCP drivers.  Dnsmasq is the simplest and requires
+# no additional setup of the DHCP server.
 dhcp_driver = <%= @dhcp_driver %>
-dhcp_domain = <%= @dhcp_domain %>
+
+# Allow overlapping IP (Must have kernel build with CONFIG_NET_NS=y and
+# iproute2 package that supports namespaces).
 use_namespaces = <%= @use_namespaces %>
+
+# The DHCP server can assist with providing metadata support on isolated
+# networks. Setting this value to True will cause the DHCP server to append
+# specific host routes to the DHCP request.  The metadata service will only
+# be activated when the subnet gateway_ip is None.  The guest instance must
+# be configured to request host routes via DHCP (Option 121).
 enable_isolated_metadata = <%= @enable_isolated_metadata %>
+
+# Allows for serving metadata requests coming from a dedicated metadata
+# access network whose cidr is 169.254.169.254/16 (or larger prefix), and
+# is connected to a Neutron router from which the VMs send metadata
+# request. In this case DHCP Option 121 will not be injected in VMs, as
+# they will be able to reach 169.254.169.254 through a router.
+# This option requires enable_isolated_metadata = True
 enable_metadata_network = <%= @enable_metadata_network %>
+
+# Number of threads to use during sync process. Should not exceed connection
+# pool size configured on server.
+# num_sync_threads = 4
+
+# Location to store DHCP server config files
+# dhcp_confs = $state_path/dhcp
+
+# Domain to use for building the hostnames
+dhcp_domain = <%= @dhcp_domain %>
+
+# Override the default dnsmasq settings with this file
+# dnsmasq_config_file =
+
+# Use another DNS server before any in /etc/resolv.conf.
+# dnsmasq_dns_server =
 <% if @nameservers -%>
 dnsmasq_dns_server = <%= @nameservers %>
 <% end -%>
+
+# Limit number of leases to prevent a denial-of-service.
+# dnsmasq_lease_max = 16777216
+
+# Location to DHCP lease relay UNIX domain socket
+# dhcp_lease_relay_socket = $state_path/dhcp/lease_relay
+
+# Location of Metadata Proxy UNIX domain socket
+# metadata_proxy_socket = $state_path/metadata_proxy

--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -1,12 +1,30 @@
 # Managed by Crowbar.
 # Do not edit.
 [DEFAULT]
+# Show debugging output in log (sets DEBUG log level output)
 debug = <%= @debug ? "True" : "False" %>
+
+# The Neutron user information for accessing the Neutron API.
 auth_url = <%= @auth_url %>
 auth_region = <%= @auth_region %>
 admin_tenant_name = <%= @admin_tenant_name %>
 admin_user = <%= @admin_user %>
 admin_password = <%= @admin_password %>
+
+# Network service endpoint type to pull from the keystone catalog
+# endpoint_type = adminURL
+
+# IP address used by Nova metadata server
 nova_metadata_ip = <%= @nova_metadata_host %>
+
+# TCP Port used by Nova metadata server
 nova_metadata_port = <%= @nova_metadata_port %>
+
+# When proxying metadata requests, Neutron signs the Instance-ID header with a
+# shared secret to prevent spoofing.  You may select any string for a secret,
+# but it must match here and in the configuration used by the Nova Metadata
+# Server. NOTE: Nova uses a different key: neutron_metadata_proxy_shared_secret
 metadata_proxy_shared_secret = <%= @metadata_proxy_shared_secret %>
+
+# Location of Metadata Proxy UNIX domain socket
+# metadata_proxy_socket = $state_path/metadata_proxy


### PR DESCRIPTION
There's no change, just all the comments from the upstream config file
to make it easier to diff things.
