### PR TITLE
Set allow_overlapping_ips to true

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_install.rb
+++ b/chef/cookbooks/neutron/recipes/common_install.rb
@@ -452,7 +452,8 @@ template "/etc/neutron/neutron.conf" do
       :per_tenant_vlan => per_tenant_vlan,
       :use_ml2 => neutron[:neutron][:use_ml2] && node[:neutron][:networking_plugin] != "vmware",
       :networking_plugin => neutron[:neutron][:networking_plugin],
-      :rootwrap_bin =>  node[:neutron][:rootwrap]
+      :rootwrap_bin =>  node[:neutron][:rootwrap],
+      :use_namespaces => true
     )
 end
 

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -99,7 +99,9 @@ auth_strategy = keystone
 # Enable or disable overlapping IPs for subnets
 # Attention: the following parameter MUST be set to False if Neutron is
 # being used in conjunction with nova security groups
+<% if @use_namespaces -%>
 allow_overlapping_ips = True
+<% end -%>
 # Ensure that configured gateway is on subnet
 # force_gateway_on_subnet = False
 


### PR DESCRIPTION
This needs to be disabled only when using nova security groups, but we
are using neutron security groups.
