### PR TITLE
Move lock_path to /var/run

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -10,7 +10,7 @@ verbose = <%= @verbose ? "True" : "False" %>
 # state_path = /var/lib/neutron
 
 # Where to store lock files
-lock_path = /var/lock/neutron
+lock_path = /var/run/neutron
 
 # log_format = %(asctime)s %(levelname)8s [%(name)s] %(message)s
 # log_date_format = %Y-%m-%d %H:%M:%S


### PR DESCRIPTION
/var/lock is blacklisted on openSUSE
