### PR TITLE
Always add hyperv to the ML2 mechanism_drivers

### DIFF
--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -14,7 +14,7 @@ tenant_network_types = <%= @networking_mode %>
 
 # (ListOpt) Ordered list of networking mechanism driver entrypoints
 # to be loaded from the neutron.ml2.mechanism_drivers namespace.
-mechanism_drivers = <%= @mechanism_driver %>
+mechanism_drivers = <%= @mechanism_driver %>,hyperv
 # Example: mechanism_drivers = arista
 # Example: mechanism_drivers = cisco,logger
 


### PR DESCRIPTION
Without this, networking won't work for Hyper-V instances. And it
shouldn't hurt for people not running Hyper-V as it won't do anything
in that case.
