### PR TITLE
Enabling "allow_overlapping_ips".

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -15,6 +15,7 @@ bind_host = <%= @service_host %>
 
 bind_port = <%= @service_port %>
 
+allow_overlapping_ips = True
 
 # ================= Syslog Options ============================
 # Send logs to syslog (/dev/log) instead of to file specified


### PR DESCRIPTION
Enable allow_overlapping_ips for neutron. It allows overlapping IPs across tenants and helps tempest to create duplicate CIDRs.
