### PR TITLE
remove openstack- prefix from user/group for SUSE

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -14,13 +14,8 @@
 # limitations under the License.
 #
 
-unless node[:platform] == "suse"
-  override[:neutron][:user]="neutron"
-  override[:neutron][:group]="neutron"
-else
-  override[:neutron][:user]="openstack-neutron"
-  override[:neutron][:group]="openstack-neutron"
-end
+override[:neutron][:user]="neutron"
+override[:neutron][:group]="neutron"
 
 default[:neutron][:debug] = false
 default[:neutron][:verbose] = false


### PR DESCRIPTION
Make this more uniform accross distributions.
