### PR TITLE
multiple assignment bug

### DIFF
--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -30,7 +30,7 @@ class NeutronService < ServiceObject
       @role_constraints ||= begin
         {
           "neutron-server" => {
-            "unique" => true,
+            "unique" => false,
             "count" => 1
           },
           "neutron-l3" => {


### PR DESCRIPTION
when I want to assign one single node to the roles `neutron-server` and `neutron-l3`,
I can do that if `neutron-server` is assigned **first**.
but if `neutron-l3` is assigned first, and i drag and drop the same node to `neutron-server`, I get the following exception:
`Failed to assign network to neutron-server, it's already assigned to another role`
so this patch makes multiple role assignment possible, when neutron-l3 is assigned before neutron-server.
