### PR TITLE
Make sure that the VLAN range is valid (bnc#870898)

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -232,7 +232,7 @@ end
 
 
 vlan_start = node[:network][:networks][:nova_fixed][:vlan]
-vlan_end = vlan_start + 2000
+vlan_end = [vlan_start + 2000, 4094].min
 
 case neutron[:neutron][:networking_plugin]
 when "openvswitch", "cisco"

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -85,7 +85,7 @@ end
 
 
 vlan_start = node[:network][:networks][:nova_fixed][:vlan]
-vlan_end = vlan_start + 2000
+vlan_end = [vlan_start + 2000, 4094].min
 
 if node[:neutron][:networking_plugin] == "cisco"
   mechanism_driver = "openvswitch,cisco_nexus"


### PR DESCRIPTION
Limit the upper bound of allowed VLAN IDs to 4094 (4095 is a reservered
IDs and cannot be used by us).
