### PR TITLE
Fix copy'n paste error in default attributes

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -142,7 +142,7 @@ end
 default[:neutron][:ha][:l3][:enabled] = false
 default[:neutron][:ha][:l3][:l3_ra] = "lsb:#{node[:neutron][:platform][:l3_agent_name]}"
 default[:neutron][:ha][:l3][:dhcp_ra] = "lsb:#{node[:neutron][:platform][:dhcp_agent_name]}"
-default[:neutron][:ha][:l3][:metadata_ra] = "lsb:#{node[:neutron][:platform][:metering_agent_name]}"
+default[:neutron][:ha][:l3][:metadata_ra] = "lsb:#{node[:neutron][:platform][:metadata_agent_name]}"
 default[:neutron][:ha][:l3][:metering_ra] = "lsb:#{node[:neutron][:platform][:metering_agent_name]}"
 default[:neutron][:ha][:l3][:openvswitch_ra] = "lsb:#{node[:neutron][:platform][:ovs_agent_name]}"
 default[:neutron][:ha][:l3][:cisco_ra] = "lsb:#{node[:neutron][:ha][:l3][:openvswitch_ra]}"


### PR DESCRIPTION
This resulted in neutron-metadata-agent to running in an HA enabled
setup. (bnc#875178)
