### PR TITLE
Tune tcp_keepalive_time for all nodes

### DIFF
--- a/chef/cookbooks/neutron/files/default/sysctl-tune-tcp_keepalive_time.conf
+++ b/chef/cookbooks/neutron/files/default/sysctl-tune-tcp_keepalive_time.conf
@@ -1,0 +1,3 @@
+net.ipv4.tcp_keepalive_time=5
+net.ipv4.tcp_keepalive_probes=5
+net.ipv4.tcp_keepalive_intvl=1

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -51,6 +51,20 @@ bash "reload disable-rp_filter-sysctl" do
   subscribes :run, resources(:cookbook_file=> disable_rp_filter_file), :delayed
 end
 
+# TCP_KEEPALIVE_TIME tunning in case of RabbitMQ crashes
+# This problem occur in non-HA and HA architecture, 
+# therefore we would like to have it on all nodes always
+tune_tcp_keepalive_time  = "/etc/sysctl.d/50-neutron-tune-tcp_keepalive_time.conf"
+cookbook_file tune_tcp_keepalive_time do
+  source "sysctl-tune-tcp_keepalive_time.conf"
+  mode "0644"
+end
+
+bash "reload tune_tcp_keepalive_time" do
+  code "/sbin/sysctl -e -q -p #{tune_tcp_keepalive_time}"
+  action :nothing
+  subscribes :run, resources(:cookbook_file=> tune_tcp_keepalive_time), :delayed
+end
 
 case neutron[:neutron][:networking_plugin]
 when "openvswitch", "cisco"


### PR DESCRIPTION
In case of RabbitMQ crashes and closing network connection for all clients we would like to have shorten the keepalive sysctl settings otherwise it will still take ~2 hrs to terminate the connections.

```
echo "5" > /proc/sys/net/ipv4/tcp_keepalive_time
echo "5" > /proc/sys/net/ipv4/tcp_keepalive_probes
echo "1" > /proc/sys/net/ipv4/tcp_keepalive_intvl
```

`tcp_keepalive_time`
- the interval between the last data packet sent (simple ACKs are not considered data) and the first keepalive probe; after the connection is marked to need keepalive, this counter is not used any further 

`tcp_keepalive_intvl`
- the interval between subsequential keepalive probes, regardless of what the connection has exchanged in the meantime 

`tcp_keepalive_probes`
- the number of unacknowledged probes to send before considering the connection dead and notifying the application layer 

http://tldp.org/HOWTO/html_single/TCP-Keepalive-HOWTO/
