### PR TITLE
Fix creation of floating network when vlan is disabled.

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -65,7 +65,11 @@ neutron_cmd = "neutron #{neutron_args}"
 floating_network_type = ""
 if node[:neutron][:networking_mode] == 'vlan'
   fixed_network_type = "--provider:network_type vlan --provider:segmentation_id #{fixed_net["vlan"]} --provider:physical_network physnet1"
-  floating_network_type = "--provider:network_type vlan --provider:segmentation_id #{floating_net["vlan"]} --provider:physical_network physnet1"
+  if node[:network][:networks][:nova_floating][:use_vlan]
+    floating_network_type = "--provider:network_type vlan --provider:segmentation_id #{floating_net["vlan"]} --provider:physical_network physnet1"
+  else
+    floating_network_type = "--provider:network_type flat --provider:physical_network physnet1"
+  end
 end
 
 if node[:neutron][:networking_plugin] == "openvswitch"


### PR DESCRIPTION
Disabling the VLAN for the nova_floating and public networks does not work correctly. While the "public" network is setup correctly the neutron barclamp does not check the "use_vlan" flag of  nova_floating" and always creates it as a provider network of type "vlan" instead using type "flat" when use_vlan is false.
