### PR TITLE
ha: Make neutron-ha-tool start after haproxy and neutron-server

### DIFF
--- a/chef/cookbooks/neutron/recipes/l3_ha.rb
+++ b/chef/cookbooks/neutron/recipes/l3_ha.rb
@@ -116,8 +116,13 @@ pacemaker_primitive ha_tool_primitive_name do
   only_if { use_l3_agent }
 end
 
+ha_tool_ordering = "#{agents_clone_name} #{ha_tool_primitive_name}"
+if node.roles.include?("neutron-server") && node[:neutron][:ha][:server][:enabled]
+  ha_tool_ordering = "g-haproxy cl-neutron-server #{agents_clone_name} #{ha_tool_primitive_name}"
+end
+
 pacemaker_order "o-neutron-ha-tool" do
-  ordering "#{agents_clone_name} #{ha_tool_primitive_name}"
+  ordering ha_tool_ordering
   score "Mandatory"
   action [ :create ]
   only_if { use_l3_agent }


### PR DESCRIPTION
Otherwise, neutron-ha-tool fails to start.

Of course, we only do that when neutron-server and neutron-l3 roles are
on the same cluster, and both with HA.
