### PR TITLE
Fix nova admin id detection

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -201,7 +201,7 @@ unless nova[:nova].nil? or nova[:nova][:ssl].nil?
   nova_api_host = CrowbarHelper.get_host_for_admin_url(nova, (nova[:nova][:ha][:server][:enabled] rescue false))
   nova_api_protocol = nova[:nova][:ssl][:enabled] ? "https" : "http"
 
-  nova_admin_tenant_id = %x[keystone --os_username #{keystone_settings['admin_user']} --os_password #{keystone_settings['admin_password']} --os_tenant_name #{keystone_settings['admin_tenant']} --os_auth_url #{keystone_settings['admin_auth_url']} tenant-get #{keystone_settings['service_tenant']} | awk '/id/  { print $4 }'].chomp
+  nova_admin_tenant_id = %x[keystone --os_username #{keystone_settings['admin_user']} --os_password #{keystone_settings['admin_password']} --os_tenant_name #{keystone_settings['admin_tenant']} --os_auth_url #{keystone_settings['public_auth_url']} tenant-get #{keystone_settings['service_tenant']} | awk '/id/  { print $4 }'].chomp
 
   nova_notify = {
     :nova_url => "#{nova_api_protocol}://#{nova_api_host}:#{nova[:nova][:ports][:api]}/v2",


### PR DESCRIPTION
With the fix of admin_auth_url to be unversioned, this regressed
as the url no longer works. We need to use the public auth url
here anyway, so switch to that.
