### PR TITLE
Handle multiple DNS forwarders correctly

### DIFF
--- a/chef/cookbooks/neutron/recipes/l3.rb
+++ b/chef/cookbooks/neutron/recipes/l3.rb
@@ -137,7 +137,7 @@ template "/etc/neutron/metering_agent.ini" do
   )
 end
 
-dns_list = node[:dns][:forwarders].join(" ")
+dns_list = node[:dns][:forwarders].join(",")
 
 template "/etc/neutron/dhcp_agent.ini" do
   source "dhcp_agent.ini.erb"


### PR DESCRIPTION
Oslo.config expects list optionts to be separated by
comma, not space (see
http://docs.openstack.org/developer/oslo.config/types.html)
