### PR TITLE
Fix listing of multiple DNS servers

### DIFF
--- a/chef/cookbooks/quantum/recipes/server.rb
+++ b/chef/cookbooks/quantum/recipes/server.rb
@@ -146,7 +146,7 @@ template "/etc/quantum/l3_agent.ini" do
   )
 end
 
-dns_list = node[:dns][:forwarders].join(" ")
+dns_list = node[:dns][:forwarders].join(",")
 
 # Ditto
 template "/etc/quantum/dhcp_agent.ini" do


### PR DESCRIPTION
This syntax error is now a fatal error with newer dnsmasq
versions. oslo.config expects lists to be separated by
colons instead of spaces.
