### PR TITLE
Don't write the "bridge_mappings" setting when using gre tunnels

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -199,7 +199,6 @@ if ['openvswitch', 'cisco', 'vmware'].include? neutron[:neutron][:networking_plu
   # Create the bridges Neutron needs.
   # Usurp config as needed.
   [ [ "nova_fixed", "fixed" ],
-    [ "os_sdn", "tunnel" ],
     [ "public", "public"] ].each do |net|
     bound_if = (node[:crowbar_wall][:network][:nets][net[0]].last rescue nil)
     next unless bound_if
@@ -208,7 +207,6 @@ if ['openvswitch', 'cisco', 'vmware'].include? neutron[:neutron][:networking_plu
       command "ovs-vsctl add-br #{name}; ip link set #{name} up"
       not_if "ovs-vsctl list-br |grep -q #{name}"
     end
-    next if net[1] == "tunnel"
     execute "Neutron: add #{bound_if} to #{name}" do
       command "ovs-vsctl del-port #{name} #{bound_if} ; ovs-vsctl add-port #{name} #{bound_if}"
       not_if "ovs-dpctl show system@#{name} | grep -q #{bound_if}"

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -278,7 +278,7 @@ when "openvswitch", "cisco"
     group "root"
     mode "0640"
     variables(
-      :physnet => neutron[:neutron][:networking_mode] == 'gre' ? "br-tunnel" : "br-fixed",
+      :physnet => neutron[:neutron][:networking_mode] == 'gre' ? nil : "br-fixed",
       :networking_mode => neutron[:neutron][:networking_mode],
       :vlan_start => vlan_start,
       :vlan_end => vlan_end

--- a/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
@@ -12,7 +12,7 @@ tenant_network_type = vlan
 network_vlan_ranges = physnet1:<%= @vlan_start %>:<%= @vlan_end %>
 <% elsif @networking_mode == 'gre' -%>
 tenant_network_type = gre
-tunnel_bridge = <%=@physnet%>
+tunnel_bridge = br-tunnel
 tunnel_id_ranges = <%= node[:neutron][:network][:gre_start]%>:<%= node[:neutron][:network][:gre_stop]%>
 local_ip = <%= node.address("os_sdn").addr %>
 enable_tunneling = True
@@ -92,7 +92,9 @@ network_vlan_ranges = physnet1
 #
 # bridge_mappings =
 # Example: bridge_mappings = physnet1:br-eth1
+<% if @physnet -%>
 bridge_mappings = physnet1:<%=@physnet%>
+<% end -%>
 
 [agent]
 # Agent's polling interval in seconds


### PR DESCRIPTION
It's unneeded and breaks the openvswitch agent's automatic creation of the
br-tunnel bridge. This allows us to cleanup the common_agent recipe a little
bit as we don't need to create the ovs-bridge there anymore.
