### PR TITLE
Use internal_auth for cross-service communication

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -201,7 +201,7 @@ unless nova[:nova].nil? or nova[:nova][:ssl].nil?
   nova_api_host = CrowbarHelper.get_host_for_admin_url(nova, (nova[:nova][:ha][:server][:enabled] rescue false))
   nova_api_protocol = nova[:nova][:ssl][:enabled] ? "https" : "http"
 
-  nova_admin_tenant_id = %x[keystone --os_username #{keystone_settings['admin_user']} --os_password #{keystone_settings['admin_password']} --os_tenant_name #{keystone_settings['admin_tenant']} --os_auth_url #{keystone_settings['public_auth_url']} tenant-get #{keystone_settings['service_tenant']} | awk '/id/  { print $4 }'].chomp
+  nova_admin_tenant_id = %x[keystone --os_username #{keystone_settings['admin_user']} --os_password #{keystone_settings['admin_password']} --os_tenant_name #{keystone_settings['admin_tenant']} --os_auth_url #{keystone_settings['internal_auth_url']} tenant-get #{keystone_settings['service_tenant']} | awk '/id/  { print $4 }'].chomp
 
   nova_notify = {
     :nova_url => "#{nova_api_protocol}://#{nova_api_host}:#{nova[:nova][:ports][:api]}/v2",


### PR DESCRIPTION
At least in one case the access over public was flakey,
and we shouldn't do this in the first place.
