### PR TITLE
Switch LBaaS on by default

### DIFF
--- a/chef/data_bags/crowbar/bc-template-neutron.json
+++ b/chef/data_bags/crowbar/bc-template-neutron.json
@@ -24,7 +24,7 @@
       "verbose": true,
       "dhcp_domain": "openstack.local",
       "use_ml2": true,
-      "use_lbaas": false,
+      "use_lbaas": true,
       "networking_mode": "gre",
       "networking_plugin": "openvswitch",
       "num_vlans": 2000,


### PR DESCRIPTION
It also causes the Service provider plugin to be loaded, which
is used by various tempest tests. And it seems people forget
about enabling it before running tempest.
