### PR TITLE
Cleanup: Remove creation of br-int

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -183,19 +183,6 @@ if ['openvswitch', 'cisco', 'vmware'].include? neutron[:neutron][:networking_plu
     end
   end
 
-  # We always need br-int.  Neutron uses this bridge internally.
-  execute "create_int_br" do
-    command "ovs-vsctl add-br br-int"
-    not_if "ovs-vsctl list-br | grep -q br-int"
-  end
-
-  # Make sure br-int is always up.
-  ruby_block "Bring up the internal bridge" do
-    block do
-      ::Nic.new('br-int').up
-    end
-  end
-
   # Create the bridges Neutron needs.
   # Usurp config as needed.
   [ [ "nova_fixed", "fixed" ],


### PR DESCRIPTION
With https://bugs.launchpad.net/neutron/+bug/1328076 fixed in icehouse we don't
need to manually create the integration bridge anymore. Neutron will do that
automatically.
