### PR TITLE
Fix check of ha enablement of l3 agent

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -260,7 +260,7 @@ end
 
 include_recipe "neutron::common_config"
 
-neutron_l3_ha = node[:neutron][:ha][:l3][:enabled]
+neutron_l3_ha = node.roles.include?("neutron-l3") && node[:neutron][:ha][:l3][:enabled]
 
 service neutron_agent do
   supports :status => true, :restart => true


### PR DESCRIPTION
When neutron-server and nova-compute are deployed on the same host (non-HA),
while neutron-l3 is deployed on separate machines in a HA cluster the check as
it was before the fix would falsely assume HA mode for the openvswitch-agent on
the compute nodes. As a result the agent is not started there.

Fixes: https://bugzilla.novell.com/show_bug.cgi?id=885832
