### PR TITLE
Synchronize configuration files for Icehouse

### DIFF
--- a/chef/cookbooks/neutron/templates/default/cisco_plugins.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/cisco_plugins.ini.erb
@@ -67,9 +67,14 @@ nexus_driver=neutron.plugins.cisco.nexus.cisco_nexus_network_driver_v2.CiscoNEXU
 nexus_driver=neutron.plugins.cisco.test.nexus.fake_nexus_driver.CiscoNEXUSFakeDriver
 <% end -%>
 
+# (BoolOpt) A flag to enable Layer 3 support on the Nexus switches.
+# Note: This feature is not supported on all models/versions of Cisco
+# Nexus switches. To use this feature, all of the Nexus switches in the
+# deployment must support it.
+# nexus_l3_enable = False
+
 # (BoolOpt) A flag to enable round robin scheduling of routers for SVI.
 # svi_round_robin = False
-
 
 # Cisco Nexus Switch configurations.
 # Each switch to be managed by Openstack Neutron must be configured here.

--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -17,6 +17,9 @@ interface_driver = <%= @interface_driver %>
 # BigSwitch/Floodlight)
 # interface_driver = neutron.agent.linux.interface.OVSInterfaceDriver
 
+# Name of Open vSwitch bridge to use
+# ovs_integration_bridge = br-int
+
 # Use veth for an OVS interface or not.
 # Support kernels with limited namespace support
 # (e.g. RHEL 6.5) so long as ovs_use_veth is set to True.
@@ -36,8 +39,8 @@ use_namespaces = <%= @use_namespaces %>
 # The DHCP server can assist with providing metadata support on isolated
 # networks. Setting this value to True will cause the DHCP server to append
 # specific host routes to the DHCP request.  The metadata service will only
-# be activated when the subnet gateway_ip is None.  The guest instance must
-# be configured to request host routes via DHCP (Option 121).
+# be activated when the subnet does not contain any router port. The guest
+# instance must be configured to request host routes via DHCP (Option 121).
 enable_isolated_metadata = <%= @enable_isolated_metadata %>
 
 # Allows for serving metadata requests coming from a dedicated metadata
@@ -61,10 +64,11 @@ dhcp_domain = <%= @dhcp_domain %>
 # Override the default dnsmasq settings with this file
 # dnsmasq_config_file =
 
-# Use another DNS server before any in /etc/resolv.conf.
-# dnsmasq_dns_server =
+# Comma-separated list of DNS servers which will be used by dnsmasq
+# as forwarders.
+# dnsmasq_dns_servers =
 <% if @nameservers -%>
-dnsmasq_dns_server = <%= @nameservers %>
+dnsmasq_dns_servers = <%= @nameservers %>
 <% end -%>
 
 # Limit number of leases to prevent a denial-of-service.

--- a/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
@@ -29,10 +29,11 @@ use_namespaces = <%= @use_namespaces %>
 # This is done by setting the specific router_id.
 # router_id =
 
-# Each L3 agent can be associated with at most one external network.  This
-# value should be set to the UUID of that external network.  If empty,
-# the agent will enforce that only a single external networks exists and
-# use that external network id
+# When external_network_bridge is set, each L3 agent can be associated
+# with no more than one external network. This value should be set to the UUID
+# of that external network. To allow L3 agent support multiple external
+# networks, both the external_network_bridge and gateway_external_network_id
+# must be left empty.
 # gateway_external_network_id =
 
 # Indicates that this L3 agent should also handle routers that do not have
@@ -42,7 +43,9 @@ use_namespaces = <%= @use_namespaces %>
 handle_internal_only_routers = <%= @handle_internal_only_routers %>
 
 # Name of bridge used for external network traffic. This should be set to
-# empty value for the linux bridge
+# empty value for the linux bridge. when this parameter is set, each L3 agent
+# can be associated with no more than one external network.
+# external_network_bridge = br-ex
 external_network_bridge = <%= @external_network_bridge %>
 
 # TCP Port used by Neutron metadata server
@@ -65,3 +68,18 @@ periodic_fuzzy_delay = <%= @periodic_fuzzy_delay %>
 
 # Location of Metadata Proxy UNIX domain socket
 # metadata_proxy_socket = $state_path/metadata_proxy
+
+# router_delete_namespaces, which is false by default, can be set to True if
+# namespaces can be deleted cleanly on the host running the L3 agent.
+# Do not enable this until you understand the problem with the Linux iproute
+# utility mentioned in https://bugs.launchpad.net/neutron/+bug/1052535 and
+# you are sure that your version of iproute does not suffer from the problem.
+# If True, namespaces will be deleted when a router is destroyed.
+# router_delete_namespaces = False
+<% if node[:platform]=="suse" -%>
+router_delete_namespaces = True
+<% end -%>
+
+# Timeout for ovs-vsctl commands.
+# If the timeout expires, ovs commands will fail with ALARMCLOCK error.
+# ovs_vsctl_timeout = 10

--- a/chef/cookbooks/neutron/templates/default/lbaas_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/lbaas_agent.ini.erb
@@ -24,10 +24,17 @@ interface_driver = <%= @interface_driver %>
 # Example of interface_driver option for LinuxBridge
 # interface_driver = neutron.agent.linux.interface.BridgeInterfaceDriver
 
-# The agent requires a driver to manage the loadbalancer.  HAProxy is the
-# opensource version.
+# The agent requires drivers to manage the loadbalancer.  HAProxy is the opensource version.
+# Multiple device drivers reflecting different service providers could be specified:
+# device_driver = path.to.provider1.driver.Driver
+# device_driver = path.to.provider2.driver.Driver
+# Default is:
 # device_driver = neutron.services.loadbalancer.drivers.haproxy.namespace_driver.HaproxyNSDriver
 device_driver = <%= @device_driver %>
+
+[haproxy]
+# Location to store config and state files
+# loadbalancer_state_path = $state_path/lbaas
 
 # The user group
 user_group = <%= @user_group %>

--- a/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
@@ -30,6 +30,8 @@ network_vlan_ranges = physnet1:<%= @vlan_start %>:<%= @vlan_end %>
 # networks listed in network_vlan_ranges on the server should have
 # mappings to appropriate interfaces on each agent.
 #
+# physical_interface_mappings =
+# Example: physical_interface_mappings = physnet1:eth1
 physical_interface_mappings = physnet1:<%=@physnet%>
 
 [vxlan]
@@ -74,3 +76,7 @@ firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
 # Firewall driver for realizing neutron security group function
 # firewall_driver = neutron.agent.firewall.NoopFirewallDriver
 # Example: firewall_driver = neutron.agent.linux.iptables_firewall.IptablesFirewallDriver
+
+# Controls if neutron security group is enabled or not.
+# It should be false when you use nova security group.
+# enable_security_group = True

--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -28,3 +28,17 @@ metadata_proxy_shared_secret = <%= @metadata_proxy_shared_secret %>
 
 # Location of Metadata Proxy UNIX domain socket
 # metadata_proxy_socket = $state_path/metadata_proxy
+
+# Number of separate worker processes for metadata server
+# metadata_workers = 0
+
+# Number of backlog requests to configure the metadata server socket with
+# metadata_backlog = 128
+
+# URL to connect to the cache backend.
+# Example of URL using memory caching backend
+# with ttl set to 5 seconds: cache_url = memory://?default_ttl=5
+# default_ttl=0 parameter will cause cache entries to never expire.
+# Otherwise default_ttl specifies time in seconds a cache entry is valid for.
+# No cache is used in case no value is passed.
+# cache_url =

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -14,9 +14,13 @@ tenant_network_types = <%= @networking_mode %>
 
 # (ListOpt) Ordered list of networking mechanism driver entrypoints
 # to be loaded from the neutron.ml2.mechanism_drivers namespace.
-mechanism_drivers = <%= @mechanism_driver %>,hyperv
+# mechanism_drivers =
+# Example: mechanism drivers = openvswitch,mlnx
 # Example: mechanism_drivers = arista
 # Example: mechanism_drivers = cisco,logger
+# Example: mechanism_drivers = openvswitch,brocade
+# Example: mechanism_drivers = linuxbridge,brocade
+mechanism_drivers = <%= @mechanism_driver %>,hyperv
 
 [ml2_type_flat]
 # (ListOpt) List of physical_network names with which flat networks
@@ -61,7 +65,9 @@ tunnel_id_ranges = <%= node[:neutron][:network][:gre_start]%>:<%= node[:neutron]
 #
 # vxlan_group =
 # Example: vxlan_group = 239.1.1.1
-#
 
 [securitygroup]
 firewall_driver = dummy_value_to_enable_security_groups_in_server
+# Controls if neutron security group is enabled or not.
+# It should be false when you use nova security group.
+# enable_security_group = True

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -1,9 +1,9 @@
 [DEFAULT]
-# Default log level is INFO
-# verbose and debug has the same result.
-# One of them will set DEBUG log level output
-debug = <%= @debug ? "True" : "False" %>
+# Print more verbose output (set logging level to INFO instead of default WARNING level).
 verbose = <%= @verbose ? "True" : "False" %>
+
+# Print debugging output (set logging level to DEBUG instead of default WARNING level).
+debug = <%= @debug ? "True" : "False" %>
 
 # Where to store Neutron state files.  This directory must be writable by the
 # user executing the agent.
@@ -31,7 +31,7 @@ log_dir = /var/log/neutron
 
 # publish_errors = False
 
-# Address to bind the API server
+# Address to bind the API server to
 bind_host = <%= @bind_host %>
 
 # Port the bind the API server to
@@ -44,7 +44,15 @@ bind_port = <%= @bind_port %>
 # extensions are in there you don't need to specify them here
 # api_extensions_path =
 
-# Neutron plugin provider module
+# (StrOpt) Neutron core plugin entrypoint to be loaded from the
+# neutron.core_plugins namespace. See setup.cfg for the entrypoint names of the
+# plugins included in the neutron source distribution. For compatibility with
+# previous versions, the class name of a plugin can be specified instead of its
+# entrypoint name.
+#
+# core_plugin =
+# Example: core_plugin = ml2
+
 <% if @use_ml2 -%>
 core_plugin = neutron.plugins.ml2.plugin.Ml2Plugin
 <% else -%>
@@ -59,8 +67,14 @@ core_plugin = neutron.plugins.nicira.NeutronPlugin.NvpPluginV2
 <%   end -%>
 <% end -%>
 
-# Advanced service modules
+# (ListOpt) List of service plugin entrypoints to be loaded from the
+# neutron.service_plugins namespace. See setup.cfg for the entrypoint names of
+# the plugins included in the neutron source distribution. For compatibility
+# with previous versions, the class name of a plugin can be specified instead
+# of its entrypoint name.
+#
 # service_plugins =
+# Example: service_plugins = router,firewall,lbaas,vpnaas,metering
 <% if @use_ml2 -%>
 service_plugins = neutron.services.l3_router.l3_router_plugin.L3RouterPlugin, <%= @service_plugins -%>
 <% else -%>
@@ -76,7 +90,7 @@ service_plugins = <%= @service_plugins -%>
 auth_strategy = keystone
 
 # Base MAC address. The first 3 octets will remain unchanged. If the
-# 4h octet is not 00, it will also used. The others will be
+# 4h octet is not 00, it will also be used. The others will be
 # randomly generated.
 # 3 octet
 # base_mac = fa:16:3e:00:00:00
@@ -137,7 +151,7 @@ rpc_backend = neutron.openstack.common.rpc.impl_kombu
 # kombu_ssl_keyfile =
 # SSL cert file (valid only if SSL enabled)
 # kombu_ssl_certfile =
-# SSL certification authority file (valid only if SSL enabled)'
+# SSL certification authority file (valid only if SSL enabled)
 # kombu_ssl_ca_certs =
 <% if @rabbit_settings -%>
 # IP address of the RabbitMQ installation
@@ -195,7 +209,7 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 
 # ============ Notification System Options =====================
 
-# Notifications can be sent when network/subnet/port are create, updated or deleted.
+# Notifications can be sent when network/subnet/port are created, updated or deleted.
 # There are three methods of sending notifications: logging (via the
 # log_file directive), rpc (via a message queue) and
 # noop (no notifications sent, the default)
@@ -205,7 +219,7 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 # notification_driver = neutron.openstack.common.notifier.no_op_notifier
 # Logging driver
 # notification_driver = neutron.openstack.common.notifier.log_notifier
-# RPC driver. DHCP agents needs it.
+# RPC driver.
 notification_driver = neutron.openstack.common.notifier.rpc_notifier
 
 # default_notification_level is used to form actual topic name(s) or to set logging level
@@ -221,7 +235,7 @@ notification_driver = neutron.openstack.common.notifier.rpc_notifier
 
 # Default maximum number of items returned in a single response,
 # value == infinite and value < 0 means no max limit, and value must
-# greater than 0. If the number of items requested is greater than
+# be greater than 0. If the number of items requested is greater than
 # pagination_max_limit, server will just return pagination_max_limit
 # of number of items.
 # pagination_max_limit = -1
@@ -238,7 +252,7 @@ notification_driver = neutron.openstack.common.notifier.rpc_notifier
 # =========== items for agent management extension =============
 # Seconds to regard the agent as down; should be at least twice
 # report_interval, to be sure the agent is down for good
-# agent_down_time = 9
+# agent_down_time = 75
 # ===========  end of items for agent management extension =====
 
 # =========== items for agent scheduler extension =============
@@ -269,6 +283,14 @@ notification_driver = neutron.openstack.common.notifier.rpc_notifier
 # worker thread in the current process.  Greater than 0 launches that number of
 # child processes as workers.  The parent process manages them.
 # api_workers = 0
+
+# Number of separate RPC worker processes to spawn.  The default, 0, runs the
+# worker thread in the current process.  Greater than 0 launches that number of
+# child processes as RPC workers.  The parent process manages them.
+# This feature is experimental until issues are addressed and testing has been
+# enabled for various plugins for compatibility.
+# rpc_workers = 0
+
 # Sets the value of TCP_KEEPIDLE in seconds to use for each server socket when
 # starting API server. Not supported on OS X.
 # tcp_keepidle = 600
@@ -278,6 +300,9 @@ notification_driver = neutron.openstack.common.notifier.rpc_notifier
 
 # Number of backlog requests to configure the socket with.
 # backlog = 4096
+
+# Max header line to accommodate large tokens
+# max_header_line = 16384
 
 # Enable SSL on the API server
 use_ssl = <%= @ssl_enabled ? "True" : "False" %>
@@ -298,11 +323,6 @@ ssl_ca_file = <%= @ssl_ca_file %>
 #ssl_ca_file = /path/to/cafile
 <% end -%>
 
-# CA certificate file to use when starting API server securely to
-# verify connecting clients. This is an optional parameter only required if
-# API clients need to authenticate to the API server using SSL certificates
-# signed by a trusted CA
-# ssl_ca_file = /path/to/cafile
 # ======== end of WSGI parameters related to the API server ==========
 
 # ======== neutron nova interactions ==========
@@ -337,29 +357,57 @@ nova_admin_auth_url = <%= @keystone_settings['internal_auth_url'] %>
 # ======== end of neutron nova interactions ==========
 
 [quotas]
-# resource name(s) that are supported in quota features
+# Default driver to use for quota checks
+# quota_driver = neutron.db.quota_db.DbQuotaDriver
+
+# Resource name(s) that are supported in quota features
 # quota_items = network,subnet,port
 
-# default number of resource allowed per tenant, minus for unlimited
+# Default number of resource allowed per tenant. A negative value means
+# unlimited.
 # default_quota = -1
 
-# number of networks allowed per tenant, and minus means unlimited
+# Number of networks allowed per tenant. A negative value means unlimited.
 # quota_network = 10
 
-# number of subnets allowed per tenant, and minus means unlimited
+# Number of subnets allowed per tenant. A negative value means unlimited.
 # quota_subnet = 10
 
-# number of ports allowed per tenant, and minus means unlimited
+# Number of ports allowed per tenant. A negative value means unlimited.
 # quota_port = 50
 
-# number of security groups allowed per tenant, and minus means unlimited
+# Number of security groups allowed per tenant. A negative value means
+# unlimited.
 # quota_security_group = 10
 
-# number of security group rules allowed per tenant, and minus means unlimited
+# Number of security group rules allowed per tenant. A negative value means
+# unlimited.
 # quota_security_group_rule = 100
 
-# default driver to use for quota checks
-# quota_driver = neutron.db.quota_db.DbQuotaDriver
+# Number of vips allowed per tenant. A negative value means unlimited.
+# quota_vip = 10
+
+# Number of pools allowed per tenant. A negative value means unlimited.
+# quota_pool = 10
+
+# Number of pool members allowed per tenant. A negative value means unlimited.
+# The default is unlimited because a member is not a real resource consumer
+# on Openstack. However, on back-end, a member is a resource consumer
+# and that is the reason why quota is possible.
+# quota_member = -1
+
+# Number of health monitors allowed per tenant. A negative value means
+# unlimited.
+# The default is unlimited because a health monitor is not a real resource
+# consumer on Openstack. However, on back-end, a member is a resource consumer
+# and that is the reason why quota is possible.
+# quota_health_monitors = -1
+
+# Number of routers allowed per tenant. A negative value means unlimited.
+# quota_router = 10
+
+# Number of floating IPs allowed per tenant. A negative value means unlimited.
+# quota_floatingip = 50
 
 [agent]
 # Use "sudo neutron-rootwrap /etc/neutron/rootwrap.conf" to use the real
@@ -370,7 +418,7 @@ root_helper=sudo <%=@rootwrap_bin%> /etc/neutron/rootwrap.conf
 # =========== items for agent management extension =============
 # seconds between nodes reporting state to server; should be less than
 # agent_down_time, best if it is half or less than agent_down_time
-# report_interval = 4
+# report_interval = 30
 
 # ===========  end of items for agent management extension =====
 
@@ -431,12 +479,24 @@ pool_timeout = <%= @sql_pool_timeout %>
 # Specify service providers (drivers) for advanced services like loadbalancer, VPN, Firewall.
 # Must be in form:
 # service_provider=<service_type>:<name>:<driver>[:default]
-# List of allowed service type include LOADBALANCER, FIREWALL, VPN
+# List of allowed service types includes LOADBALANCER, FIREWALL, VPN
 # Combination of <service type> and <name> must be unique; <driver> must also be unique
-# this is multiline option, example for default provider:
-<% if node[:neutron][:use_lbaas] %>
-service_provider=LOADBALANCER:Haproxy:neutron.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
-<% end -%>
+# This is multiline option, example for default provider:
 # service_provider=LOADBALANCER:name:lbaas_plugin_driver_path:default
 # example of non-default provider:
 # service_provider=FIREWALL:name2:firewall_driver_path
+# --- Reference implementations ---
+<% if node[:neutron][:use_lbaas] %>
+service_provider=LOADBALANCER:Haproxy:neutron.services.loadbalancer.drivers.haproxy.plugin_driver.HaproxyOnHostPluginDriver:default
+<% end -%>
+#service_provider=VPN:openswan:neutron.services.vpn.service_drivers.ipsec.IPsecVPNDriver:default
+# In order to activate Radware's lbaas driver you need to uncomment the next line.
+# If you want to keep the HA Proxy as the default lbaas driver, remove the attribute default from the line below.
+# Otherwise comment the HA Proxy line
+# service_provider = LOADBALANCER:Radware:neutron.services.loadbalancer.drivers.radware.driver.LoadBalancerDriver:default
+# uncomment the following line to make the 'netscaler' LBaaS provider available.
+# service_provider=LOADBALANCER:NetScaler:neutron.services.loadbalancer.drivers.netscaler.netscaler_driver.NetScalerPluginDriver
+# Uncomment the following line (and comment out the OpenSwan VPN line) to enable Cisco's VPN driver.
+# service_provider=VPN:cisco:neutron.services.vpn.service_drivers.cisco_ipsec.CiscoCsrIPsecVPNDriver:default
+# Uncomment the line below to use Embrane heleos as Load Balancer service provider.
+# service_provider=LOADBALANCER:Embrane:neutron.services.loadbalancer.drivers.embrane.driver.EmbraneLbaas:default

--- a/chef/cookbooks/neutron/templates/default/nvp.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/nvp.ini.erb
@@ -1,29 +1,16 @@
-# #############################################################
-# WARNINGS: The following deprecations have been made in the
-# Havana release. Support for the options below will be removed
-# in Ixxx.
-#
-# Section: [DEFAULT], Option: 'metadata_dhcp_host_route'
-# Remarks: Use 'enable_isolated_metadata' in dhcp_agent.ini.
-#
-#
-# Section: [cluster:name], Option: 'nvp_controller_connection'
-# Remarks: The configuration will allow the specification of
-#          a single cluster, therefore [cluster:name] is no
-#          longer used.  Use 'nvp_*', options, 'req_timeout',
-#          'retries', etc. as indicated in the DEFAULT section.
-#          Support for multiple clusters will be added through
-#          an API extension.
-# ##############################################################
+# Nicira and NVP are going to be replaced with VMware and
+# NSX during the Icehouse timeframe. The old configuration
+# file plugins/nicira/nvp.ini is going to be removed soon.
+# Please consider using plugins/vmware/nsx.ini, instead.
 
 [DEFAULT]
-# User name for NVP controller
-#nvp_user = admin
-<%= "nvp_user = #{node[:neutron][:vmware][:user]}" %>
+# User name for NSX controller
+# nsx_user = admin
+<%= "nsx_user = #{node[:neutron][:vmware][:user]}" %>
 
-# Password for NVP controller
-#nvp_password = admin
-<%= "nvp_password = #{node[:neutron][:vmware][:password]}" %>
+# Password for NSX controller
+# nsx_password = admin
+<%= "nsx_password = #{node[:neutron][:vmware][:password]}" %>
 
 # Total time limit for a cluster request
 # (including retries across different controllers)
@@ -38,12 +25,12 @@
 # Maximum number of times a redirect response should be followed
 # redirects = 2
 
-# Comma-separated list of NVP controller endpoints (<ip>:<port>). When port
+# Comma-separated list of NSX controller endpoints (<ip>:<port>). When port
 # is omitted, 443 is assumed. This option MUST be specified, e.g.:
-# nvp_controllers = xx.yy.zz.ww:443, aa.bb.cc.dd, ee.ff.gg.hh.ee:80
-<%= "nvp_controllers = #{node[:neutron][:vmware][:controllers]}" %>
+# nsx_controllers = xx.yy.zz.ww:443, aa.bb.cc.dd, ee.ff.gg.hh.ee:80
+<%= "nsx_controllers = #{node[:neutron][:vmware][:controllers]}" %>
 
-# UUID of the pre-existing default NVP Transport zone to be used for creating
+# UUID of the pre-existing default NSX Transport zone to be used for creating
 # tunneled isolated "Neutron" networks. This option MUST be specified, e.g.:
 # default_tz_uuid = 1e8e52cf-fa7f-46b0-a14a-f99835a9cb53
 <%= "default_tz_uuid = #{node[:neutron][:vmware][:tz_uuid]}" %>
@@ -57,6 +44,12 @@
 # To be specified for providing a predefined gateway tenant for connecting their networks.
 # default_l2_gw_service_uuid =
 
+# (Optional) UUID for the default service cluster. A service cluster is introduced to
+# represent a group of gateways and it is needed in order to use Logical Services like
+# dhcp and metadata in the logical space. NOTE: If agent_mode is set to 'agentless' this
+# config parameter *MUST BE* set to a valid pre-existent service cluster uuid.
+# default_service_cluster_uuid =
+
 # Name of the default interface name to be used on network-gateway.  This value
 # will be used for any device associated with a network gateway for which an
 # interface name was not specified
@@ -65,87 +58,6 @@
 [quotas]
 # number of network gateways allowed per tenant, -1 means unlimited
 # quota_network_gateway = 5
-
-
-[nvp]
-# Maximum number of ports for each bridged logical switch
-# The recommended value for this parameter varies with NVP version
-# Please use:
-# NVP 2.x -> 64
-# NVP 3.0, 3.1 -> 5000
-# NVP 3.2 -> 10000
-# max_lp_per_bridged_ls = 5000
-
-# Maximum number of ports for each overlay (stt, gre) logical switch
-# max_lp_per_overlay_ls = 256
-
-# Number of connections to each controller node.
-# default is 10
-# concurrent_connections = 10
-
-# Number of seconds a generation id should be valid for (default -1 meaning do not time out)
-# nvp_gen_timeout = -1
-
-# Acceptable values for 'metadata_mode' are:
-#   - 'access_network': this enables a dedicated connection to the metadata
-#     proxy for metadata server access via Neutron router.
-#   - 'dhcp_host_route': this enables host route injection via the dhcp agent.
-# This option is only useful if running on a host that does not support
-# namespaces otherwise access_network should be used.
-# metadata_mode = access_network
-
-# The default network transport type to use (stt, gre, bridge, ipsec_gre, or ipsec_stt)
-default_transport_type = gre
-
-# Specifies in which mode the plugin needs to operate in order to provide DHCP and
-# metadata proxy services to tenant instances. If 'agent' is chosen (default)
-# the NVP plugin relies on external RPC agents (i.e. dhcp and metadata agents) to
-# provide such services. In this mode, the plugin supports API extensions 'agent'
-# and 'dhcp_agent_scheduler'. If 'agentless' is chosen (experimental in Havana),
-# the plugin will use NVP logical services for DHCP and metadata proxy. This
-# simplifies the deployment model for Neutron, in that the plugin no longer requires
-# the RPC agents to operate. When 'agentless' is chosen, the config option metadata_mode
-# becomes ineffective. The mode 'agentless' is not supported for NVP 3.2 or below.
-# agent_mode = agent
-
-[nvp_sync]
-# Interval in seconds between runs of the status synchronization task.
-# The plugin will aim at resynchronizing operational status for all
-# resources in this interval, and it should be therefore large enough
-# to ensure the task is feasible. Otherwise the plugin will be
-# constantly synchronizing resource status, ie: a new task is started
-# as soon as the previous is completed.
-# If this value is set to 0, the state synchronization thread for this
-# Neutron instance will be disabled.
-# state_sync_interval = 120
-
-# Random additional delay between two runs of the state synchronization task.
-# An additional wait time between 0 and max_random_sync_delay seconds
-# will be added on top of state_sync_interval.
-# max_random_sync_delay = 0
-
-# Minimum delay, in seconds, between two status synchronization requests for NVP.
-# Depending on chunk size, controller load, and other factors, state
-# synchronization requests might be pretty heavy. This means the
-# controller might take time to respond, and its load might be quite
-# increased by them. This parameter allows to specify a minimum
-# interval between two subsequent requests.
-# The value for this parameter must never exceed state_sync_interval.
-# If this does, an error will be raised at startup.
-# min_sync_req_delay = 10
-
-# Minimum number of resources to be retrieved from NVP in a single status
-# synchronization request.
-# The actual size of the chunk will increase if the number of resources is such
-# that using the minimum chunk size will cause the interval between two
-# requests to be less than min_sync_req_delay
-# min_chunk_size = 500
-
-# Enable this option to allow punctual state synchronization on show
-# operations. In this way, show operations will always fetch the operational
-# status of the resource from the NVP backend, and this might have
-# a considerable impact on overall performance.
-# always_read_status = False
 
 [vcns]
 # URL for VCNS manager
@@ -177,3 +89,124 @@ default_transport_type = gre
 # (Optional) Asynchronous task status check interval
 # default is 2000 (millisecond)
 # task_status_check_interval = 2000
+
+[nsx]
+# Maximum number of ports for each bridged logical switch
+# The recommended value for this parameter varies with NSX version
+# Please use:
+# NSX 2.x -> 64
+# NSX 3.0, 3.1 -> 5000
+# NSX 3.2 -> 10000
+# max_lp_per_bridged_ls = 5000
+
+# Maximum number of ports for each overlay (stt, gre) logical switch
+# max_lp_per_overlay_ls = 256
+
+# Number of connections to each controller node.
+# default is 10
+# concurrent_connections = 10
+
+# Number of seconds a generation id should be valid for (default -1 meaning do not time out)
+# nsx_gen_timeout = -1
+
+# Acceptable values for 'metadata_mode' are:
+#   - 'access_network': this enables a dedicated connection to the metadata
+#     proxy for metadata server access via Neutron router.
+#   - 'dhcp_host_route': this enables host route injection via the dhcp agent.
+# This option is only useful if running on a host that does not support
+# namespaces otherwise access_network should be used.
+# metadata_mode = access_network
+
+# The default network transport type to use (stt, gre, bridge, ipsec_gre, or ipsec_stt)
+default_transport_type = gre
+
+# Specifies in which mode the plugin needs to operate in order to provide DHCP and
+# metadata proxy services to tenant instances. If 'agent' is chosen (default)
+# the NSX plugin relies on external RPC agents (i.e. dhcp and metadata agents) to
+# provide such services. In this mode, the plugin supports API extensions 'agent'
+# and 'dhcp_agent_scheduler'. If 'agentless' is chosen (experimental in Icehouse),
+# the plugin will use NSX logical services for DHCP and metadata proxy. This
+# simplifies the deployment model for Neutron, in that the plugin no longer requires
+# the RPC agents to operate. When 'agentless' is chosen, the config option metadata_mode
+# becomes ineffective. The 'agentless' mode is supported from NSX 4.2 or above.
+# Furthermore, a 'combined' mode is also provided and is used to support existing
+# deployments that want to adopt the agentless mode going forward. With this mode,
+# existing networks keep being served by the existing infrastructure (thus preserving
+# backward compatibility, whereas new networks will be served by the new infrastructure.
+# Migration tools are provided to 'move' one network from one model to another; with
+# agent_mode set to 'combined', option 'network_auto_schedule' in neutron.conf is
+# ignored, as new networks will no longer be scheduled to existing dhcp agents.
+# agent_mode = agent
+
+# Specifies which mode packet replication should be done in. If set to service
+# a service node is required in order to perform packet replication. This can
+# also be set to source if one wants replication to be performed locally (NOTE:
+# usually only useful for testing if one does not want to deploy a service node).
+# replication_mode = service
+
+[nsx_sync]
+# Interval in seconds between runs of the status synchronization task.
+# The plugin will aim at resynchronizing operational status for all
+# resources in this interval, and it should be therefore large enough
+# to ensure the task is feasible. Otherwise the plugin will be
+# constantly synchronizing resource status, ie: a new task is started
+# as soon as the previous is completed.
+# If this value is set to 0, the state synchronization thread for this
+# Neutron instance will be disabled.
+# state_sync_interval = 120
+
+# Random additional delay between two runs of the state synchronization task.
+# An additional wait time between 0 and max_random_sync_delay seconds
+# will be added on top of state_sync_interval.
+# max_random_sync_delay = 0
+
+# Minimum delay, in seconds, between two status synchronization requests for NSX.
+# Depending on chunk size, controller load, and other factors, state
+# synchronization requests might be pretty heavy. This means the
+# controller might take time to respond, and its load might be quite
+# increased by them. This parameter allows to specify a minimum
+# interval between two subsequent requests.
+# The value for this parameter must never exceed state_sync_interval.
+# If this does, an error will be raised at startup.
+# min_sync_req_delay = 10
+
+# Minimum number of resources to be retrieved from NSX in a single status
+# synchronization request.
+# The actual size of the chunk will increase if the number of resources is such
+# that using the minimum chunk size will cause the interval between two
+# requests to be less than min_sync_req_delay
+# min_chunk_size = 500
+
+# Enable this option to allow punctual state synchronization on show
+# operations. In this way, show operations will always fetch the operational
+# status of the resource from the NSX backend, and this might have
+# a considerable impact on overall performance.
+# always_read_status = False
+
+[nsx_lsn]
+# Pull LSN information from NSX in case it is missing from the local
+# data store. This is useful to rebuild the local store in case of
+# server recovery
+# sync_on_missing_data = False
+
+[nsx_dhcp]
+# (Optional) Comma separated list of additional dns servers. Default is an empty list
+# extra_domain_name_servers =
+
+# Domain to use for building the hostnames
+# domain_name = openstacklocal
+
+# Default DHCP lease time
+# default_lease_time = 43200
+
+[nsx_metadata]
+# IP address used by Metadata server
+# metadata_server_address = 127.0.0.1
+
+# TCP Port used by Metadata server
+# metadata_server_port = 8775
+
+# When proxying metadata requests, Neutron signs the Instance-ID header with a
+# shared secret to prevent spoofing. You may select any string for a secret,
+# but it MUST match with the configuration used by the Metadata server
+# metadata_shared_secret =

--- a/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
@@ -7,6 +7,9 @@
 # tenant networks to provide connectivity between hosts. Set to 'none'
 # to disable creation of tenant networks.
 #
+# tenant_network_type = local
+# Example: tenant_network_type = gre
+# Example: tenant_network_type = vxlan
 <% if @networking_mode == 'vlan' -%>
 tenant_network_type = vlan
 network_vlan_ranges = physnet1:<%= @vlan_start %>:<%= @vlan_end %>
@@ -100,6 +103,13 @@ bridge_mappings = physnet1:<%=@physnet%>
 # Agent's polling interval in seconds
 # polling_interval = 2
 
+# Minimize polling by monitoring ovsdb for interface changes
+# minimize_polling = True
+
+# When minimize_polling = True, the number of seconds to wait before
+# respawning the ovsdb monitor after losing communication with it
+# ovsdb_monitor_respawn_interval = 30
+
 # (ListOpt) The types of tenant network tunnels supported by the agent.
 # Setting this will enable tunneling support in the agent. This can be set to
 # either 'gre' or 'vxlan'. If this is unset, it will default to [] and
@@ -135,32 +145,42 @@ bridge_mappings = physnet1:<%=@physnet%>
 # l2_population = False
 
 [securitygroup]
-firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
 # Firewall driver for realizing neutron security group function.
 # firewall_driver = neutron.agent.firewall.NoopFirewallDriver
 # Example: firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+firewall_driver = neutron.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver
+
+# Controls if neutron security group is enabled or not.
+# It should be false when you use nova security group.
+# enable_security_group = True
 
 #-----------------------------------------------------------------------------
 # Sample Configurations.
 #-----------------------------------------------------------------------------
 #
 # 1. With VLANs on eth1.
-# [database]
-# connection = mysql://root:nova@127.0.0.1:3306/ovs_neutron
-# [OVS]
+# [ovs]
 # network_vlan_ranges = default:2000:3999
 # tunnel_id_ranges =
 # integration_bridge = br-int
 # bridge_mappings = default:br-eth1
-# [AGENT]
-# Add the following setting, if you want to log to a file
 #
-# 2. With tunneling.
-# [database]
-# connection = mysql://root:nova@127.0.0.1:3306/ovs_neutron
-# [OVS]
+# 2. With GRE tunneling.
+# [ovs]
 # network_vlan_ranges =
 # tunnel_id_ranges = 1:1000
 # integration_bridge = br-int
 # tunnel_bridge = br-tun
 # local_ip = 10.0.0.3
+#
+# 3. With VXLAN tunneling.
+# [ovs]
+# network_vlan_ranges =
+# tenant_network_type = vxlan
+# tunnel_type = vxlan
+# tunnel_id_ranges = 1:1000
+# integration_bridge = br-int
+# tunnel_bridge = br-tun
+# local_ip = 10.0.0.3
+# [agent]
+# tunnel_types = vxlan


### PR DESCRIPTION
Worth mentioning:
- we set router_delete_namespaces in l3_agent.ini to True for SUSE.
  After reading https://bugs.launchpad.net/neutron/+bug/1052535, what
  matters is that iproute2 must have this patch:
  https://git.kernel.org/cgit/linux/kernel/git/shemminger/iproute2.git/commit/?id=58a3e8270fe72f8ed92687d3a3132c2a708582dd
  which is the case on SUSE.
- many config options in nvp.ini got renamed from nvp_\* to nsx_*
