### PR TITLE
Fix handling of multiple DNS servers

### DIFF
--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -64,7 +64,8 @@ dhcp_domain = <%= @dhcp_domain %>
 # Use another DNS server before any in /etc/resolv.conf.
 # dnsmasq_dns_server =
 <% if @nameservers -%>
-dnsmasq_dns_server = <%= @nameservers %>
+dnsmasq_dns_server = <%= @nameservers.split(',').first %>
+dnsmasq_dns_servers = <%= @nameservers %>
 <% end -%>
 
 # Limit number of leases to prevent a denial-of-service.


### PR DESCRIPTION
dnsmasq_dns_server was renamed to dnsmasq_dns_servers to handle
multiple DNS servers. Depending on which package is being installed
either dnsmasq_dns_server or dnsmasq_dns_servers is needed to be set.
It doesn't hurt to set both though.
