### PR TITLE
Fix search for nova instance

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -83,7 +83,15 @@ else
   bind_port = neutron[:neutron][:api][:service_port]
 end
 
-nova = get_instance("roles:nova-multi-controller")
+#TODO: nova should depend on neutron, but neutron also depends on nova
+# so we have to do something like this
+novas = search(:node, "roles:nova-multi-controller") || []
+if novas.length > 0
+  nova = novas[0]
+  nova = node if nova.name == node.name
+else
+  nova = node
+end
 nova_notify = {}
 
 unless nova[:nova].nil? or nova[:nova][:ssl].nil?

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -149,7 +149,7 @@ class NeutronService < PacemakerServiceObject
     net_svc = NetworkService.new @logger
     network_proposal = ProposalObject.find_proposal(net_svc.bc_name, "default")
     blacklist = ['bmc', 'bmc_admin', 'admin', 'nova_fixed', 'nova_floating',
-                 'os_sdn', 'public', 'storage'] 
+                 'os_sdn', 'public', 'storage']
 
     external_networks.each do |ext_net|
       # Exclude a few default networks from network.json from being used as


### PR DESCRIPTION
When nova-multi-controller and neutron-server are deployed
on two different nodes, the neutron.conf was not properly updated
with the nova settings because it could't find the node. Search
for the instance (optional since normal deployment order currently
is neutron first, then nova) properly so that get_instance()
in the chef recipe can do its job.