### PR TITLE
Ensure that api-paste.ini does not contain the auth_token

### DIFF
--- a/chef/cookbooks/neutron/files/default/api-paste.ini
+++ b/chef/cookbooks/neutron/files/default/api-paste.ini
@@ -1,0 +1,30 @@
+[composite:neutron]
+use = egg:Paste#urlmap
+/: neutronversions
+/v2.0: neutronapi_v2_0
+
+[composite:neutronapi_v2_0]
+use = call:neutron.auth:pipeline_factory
+noauth = request_id catch_errors extensions neutronapiapp_v2_0
+keystone = request_id catch_errors authtoken keystonecontext extensions neutronapiapp_v2_0
+
+[filter:request_id]
+paste.filter_factory = neutron.openstack.common.middleware.request_id:RequestIdMiddleware.factory
+
+[filter:catch_errors]
+paste.filter_factory = neutron.openstack.common.middleware.catch_errors:CatchErrorsMiddleware.factory
+
+[filter:keystonecontext]
+paste.filter_factory = neutron.auth:NeutronKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
+
+[filter:extensions]
+paste.filter_factory = neutron.api.extensions:plugin_aware_extension_middleware_factory
+
+[app:neutronversions]
+paste.app_factory = neutron.api.versions:Versions.factory
+
+[app:neutronapiapp_v2_0]
+paste.app_factory = neutron.api.v2.router:APIRouter.factory

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -31,6 +31,22 @@ include_recipe "neutron::database"
 include_recipe "neutron::common_config"
 
 
+# XXX this is no different from the file provided in the package, but
+# since we used to have a configured template here, we need to make sure
+# that it gets overwritten specifically since it used to contain
+# auth_token configuration options which conflict with the ones in
+# neutron.conf and the packages won't overwrite a modified file.
+# This block can be removed when either neutron does not read auth_token
+# configuration from api-paste.ini or we are sure that the target
+# machine no longer has an api-paste.ini file with the auth_token settings
+cookbook_file "api-paste.ini" do
+  path "/etc/neutron/api-paste.ini"
+  owner "root"
+  group node[:neutron][:group]
+  mode "0640"
+  action :create
+end
+
 if node[:neutron][:use_ml2] && node[:neutron][:networking_plugin] != "vmware"
   plugin_cfg_path = "/etc/neutron/plugins/ml2/ml2_conf.ini"
 else


### PR DESCRIPTION
Since commit 444211b removed the api-paste.ini template from chef, systems
which already had it installed by chef would keep the old version because it
was modified outside of rpm. But these files contained the auth_token
middleware configuration which would conflict with the one from neutron.conf.

This commit fixes that problem by making sure to overwrite api-paste.ini
with a vanilla file from the git repository (current stable/icehouse).
