### PR TITLE
Sync api-paste with Juno

### DIFF
--- a/chef/cookbooks/neutron/files/default/api-paste.ini
+++ b/chef/cookbooks/neutron/files/default/api-paste.ini
@@ -18,7 +18,7 @@ paste.filter_factory = neutron.openstack.common.middleware.catch_errors:CatchErr
 paste.filter_factory = neutron.auth:NeutronKeystoneContext.factory
 
 [filter:authtoken]
-paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 
 [filter:extensions]
 paste.filter_factory = neutron.api.extensions:plugin_aware_extension_middleware_factory


### PR DESCRIPTION
Juno uses keystonemiddleware meanwhile.
