### PR TITLE
Properly quote the values of keystone arguments

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -183,7 +183,7 @@ unless nova[:nova].nil? or nova[:nova][:ssl].nil?
   nova_api_protocol = nova[:nova][:ssl][:enabled] ? "https" : "http"
   keystone_insecure = keystone_settings['insecure'] ? "--insecure" : ""
 
-  nova_admin_tenant_id = %x[keystone --os_username #{keystone_settings['admin_user']} --os_password #{keystone_settings['admin_password']} --os_tenant_name #{keystone_settings['admin_tenant']} --os_auth_url #{keystone_settings['internal_auth_url']} #{keystone_insecure} tenant-get #{keystone_settings['service_tenant']} | awk '/id/  { print $4 }'].chomp
+  nova_admin_tenant_id = %x[keystone --os_username '#{keystone_settings['admin_user']}' --os_password '#{keystone_settings['admin_password']}' --os_tenant_name '#{keystone_settings['admin_tenant']}' --os_auth_url '#{keystone_settings['internal_auth_url']}' #{keystone_insecure} tenant-get '#{keystone_settings['service_tenant']}' | awk '/id/  { print $4 }'].chomp
 
   nova_notify = {
     :nova_url => "#{nova_api_protocol}://#{nova_api_host}:#{nova[:nova][:ports][:api]}/v2",


### PR DESCRIPTION
To avoid shell expansion e.g. when a value contains a '$' sign.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=896750
