### PR TITLE
Use region from keystone settings

### DIFF
--- a/chef/cookbooks/neutron/recipes/api_register.rb
+++ b/chef/cookbooks/neutron/recipes/api_register.rb
@@ -72,7 +72,7 @@ keystone_register "register neutron endpoint" do
   port keystone_settings['admin_port']
   token keystone_settings['admin_token']
   endpoint_service "neutron"
-  endpoint_region "RegionOne"
+  endpoint_region keystone_settings['endpoint_region']
   endpoint_publicURL "#{neutron_protocol}://#{my_public_host}:#{api_port}/"
   endpoint_adminURL "#{neutron_protocol}://#{my_admin_host}:#{api_port}/"
   endpoint_internalURL "#{neutron_protocol}://#{my_admin_host}:#{api_port}/"

--- a/chef/cookbooks/neutron/recipes/l3.rb
+++ b/chef/cookbooks/neutron/recipes/l3.rb
@@ -184,7 +184,7 @@ template "/etc/neutron/metadata_agent.ini" do
   variables(
     :debug => node[:neutron][:debug],
     :keystone_settings => keystone_settings,
-    :auth_region => "RegionOne",
+    :auth_region => keystone_settings['endpoint_region'],
     :neutron_insecure => node[:neutron][:ssl][:insecure],
     :nova_metadata_host => metadata_host,
     :nova_metadata_port => metadata_port,

--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -53,6 +53,7 @@ neutron_args = "--os-username #{keystone_settings['service_user']}"
 neutron_args = "#{neutron_args} --os-password #{keystone_settings['service_password']}"
 neutron_args = "#{neutron_args} --os-tenant-name #{keystone_settings['service_tenant']}"
 neutron_args = "#{neutron_args} --os-auth-url #{keystone_settings['internal_auth_url']}"
+neutron_args = "#{neutron_args} --os-region-name #{keystone_settings['endpoint_region']}"
 if node[:platform] == "suse" or node[:neutron][:use_gitrepo]
   # these options are backported in SUSE packages, but not in Ubuntu
   neutron_args = "#{neutron_args} --endpoint-type internalURL"


### PR DESCRIPTION
The keystone barclamp got the possibility to set a custom region
name. This name must be used by other barclamps as well.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481
