### PR TITLE
Add "insecure" and ca cert options to nova notification (bnc#912647)

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -182,11 +182,15 @@ unless nova[:nova].nil? or nova[:nova][:ssl].nil?
   nova_api_host = CrowbarHelper.get_host_for_admin_url(nova, (nova[:nova][:ha][:enabled] rescue false))
   nova_api_protocol = nova[:nova][:ssl][:enabled] ? "https" : "http"
   keystone_insecure = keystone_settings['insecure'] ? "--insecure" : ""
+  nova_insecure = nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]
+  nova_ssl_cacerts = nova[:nova][:ssl][:ca_certs] unless nova_insecure
 
   nova_admin_tenant_id = %x[keystone --os_username '#{keystone_settings['admin_user']}' --os_password '#{keystone_settings['admin_password']}' --os_tenant_name '#{keystone_settings['admin_tenant']}' --os_auth_url '#{keystone_settings['internal_auth_url']}' #{keystone_insecure} tenant-get '#{keystone_settings['service_tenant']}' | awk '/id/  { print $4 }'].chomp
 
   nova_notify = {
     :nova_url => "#{nova_api_protocol}://#{nova_api_host}:#{nova[:nova][:ports][:api]}/v2",
+    :nova_insecure => nova_insecure,
+    :nova_ssl_cacerts => nova_ssl_cacerts || nil,
     :nova_admin_username => nova[:nova][:service_user],
     :nova_admin_tenant_id => nova_admin_tenant_id,
     :nova_admin_password => nova[:nova][:service_password]

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -351,6 +351,18 @@ nova_admin_password = <%= @nova_admin_password if @nova_admin_password %>
 # Authorization URL for connection to nova in admin context.
 nova_admin_auth_url = <%= @keystone_settings['internal_auth_url'] %>
 
+# CA file for novaclient to verify server certificates
+# nova_ca_certificates_file =
+<% if @nova_ssl_cacerts -%>
+nova_ca_certificates_file = <%= @nova_ssl_cacerts %>
+<% end -%>
+
+# Boolean to control ignoring SSL errors on the nova url
+# nova_api_insecure = False
+<% if @nova_insecure -%>
+nova_api_insecure = <%= @nova_insecure %>
+<% end -%>
+
 # Number of seconds between sending events to nova if there are any events to send
 # send_events_interval = 2
 


### PR DESCRIPTION
This requires the following patches in neutron to be backported to Icehouse:

https://review.openstack.org/#/c/88673/
https://review.openstack.org/#/c/87085/

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=912647