### PR TITLE
Fix for OpenVSwitch with VLAN mode

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -69,15 +69,9 @@ if node[:neutron][:networking_mode] == 'vlan'
   else
     floating_network_type = "--provider:network_type flat --provider:physical_network physnet1"
   end
-end
-
-if node[:neutron][:networking_plugin] == "openvswitch"
-  if node[:neutron][:networking_mode] == 'gre'
-    fixed_network_type = "--provider:network_type gre --provider:segmentation_id 1"
-    floating_network_type = "--provider:network_type gre --provider:segmentation_id 2"
-  else
-    fixed_network_type = "--provider:network_type flat --provider:physical_network physnet1"
-  end
+elsif node[:neutron][:networking_mode] == 'gre'
+  fixed_network_type = "--provider:network_type gre --provider:segmentation_id 1"
+  floating_network_type = "--provider:network_type gre --provider:segmentation_id 2"
 end
 
 if node[:neutron][:networking_plugin] == "vmware"


### PR DESCRIPTION
This line is not needed any more, it cause overwriting
segmentation_id when openvswitch and vlan mode is chose.