### PR TITLE
Remove || nil that makes no sense

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -190,7 +190,7 @@ unless nova[:nova].nil? or nova[:nova][:ssl].nil?
   nova_notify = {
     :nova_url => "#{nova_api_protocol}://#{nova_api_host}:#{nova[:nova][:ports][:api]}/v2",
     :nova_insecure => nova_insecure,
-    :nova_ssl_cacerts => nova_ssl_cacerts || nil,
+    :nova_ssl_cacerts => nova_ssl_cacerts,
     :nova_admin_username => nova[:nova][:service_user],
     :nova_admin_tenant_id => nova_admin_tenant_id,
     :nova_admin_password => nova[:nova][:service_password]


### PR DESCRIPTION
The line defining the variable is:
  nova_ssl_cacerts = nova[:nova][:ssl][:ca_certs] unless nova_insecure

nova_ssl_cacerts will be set to nil if nova_insecure is true. And "||
nil" has no impact on empty strings, so it's just redundant.