### PR TITLE
Move SSL related checks to server recipe

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -49,8 +49,6 @@ default[:neutron][:ssl][:insecure] = false
 default[:neutron][:ssl][:cert_required] = false
 default[:neutron][:ssl][:ca_certs] = "/etc/neutron/ssl/certs/ca.pem"
 
-default[:neutron][:neutron_server] = false
-
 case node["platform"]
 when "suse"
   default[:neutron][:platform] = {

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -21,8 +21,6 @@ if node.attribute?(:cookbook) and node[:cookbook] == "nova"
 else
   neutron = node
 end
-neutron_server = node[:neutron][:neutron_server] rescue false
-
 
 # Disable rp_filter
 ruby_block "edit /etc/sysctl.conf for rp_filter" do

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -26,10 +26,74 @@ else
   end
 end
 
-
 include_recipe "neutron::database"
-include_recipe "neutron::common_config"
 
+if node[:neutron][:api][:protocol] == 'https'
+  if node[:neutron][:ssl][:generate_certs]
+    package "openssl"
+    ruby_block "generate_certs for neutron" do
+      block do
+        unless ::File.exists? node[:neutron][:ssl][:certfile] and ::File.exists? node[:neutron][:ssl][:keyfile]
+          require "fileutils"
+
+          Chef::Log.info("Generating SSL certificate for neutron...")
+
+          [:certfile, :keyfile].each do |k|
+            dir = File.dirname(node[:neutron][:ssl][k])
+            FileUtils.mkdir_p(dir) unless File.exists?(dir)
+          end
+
+          # Generate private key
+          %x(openssl genrsa -out #{node[:neutron][:ssl][:keyfile]} 4096)
+          if $?.exitstatus != 0
+            message = "SSL private key generation failed"
+            Chef::Log.fatal(message)
+            raise message
+          end
+          FileUtils.chown "root", node[:neutron][:group], node[:neutron][:ssl][:keyfile]
+          FileUtils.chmod 0640, node[:neutron][:ssl][:keyfile]
+
+          # Generate certificate signing requests (CSR)
+          conf_dir = File.dirname node[:neutron][:ssl][:certfile]
+          ssl_csr_file = "#{conf_dir}/signing_key.csr"
+          ssl_subject = "\"/C=US/ST=Unset/L=Unset/O=Unset/CN=#{node[:fqdn]}\""
+          %x(openssl req -new -key #{node[:neutron][:ssl][:keyfile]} -out #{ssl_csr_file} -subj #{ssl_subject})
+          if $?.exitstatus != 0
+            message = "SSL certificate signed requests generation failed"
+            Chef::Log.fatal(message)
+            raise message
+          end
+
+          # Generate self-signed certificate with above CSR
+          %x(openssl x509 -req -days 3650 -in #{ssl_csr_file} -signkey #{node[:neutron][:ssl][:keyfile]} -out #{node[:neutron][:ssl][:certfile]})
+          if $?.exitstatus != 0
+            message = "SSL self-signed certificate generation failed"
+            Chef::Log.fatal(message)
+            raise message
+          end
+
+          File.delete ssl_csr_file  # Nobody should even try to use this
+        end # unless files exist
+      end # block
+    end # ruby_block
+  else # if generate_certs
+    unless ::File.exists? node[:neutron][:ssl][:certfile]
+      message = "Certificate \"#{node[:neutron][:ssl][:certfile]}\" is not present."
+      Chef::Log.fatal(message)
+      raise message
+    end
+    # we do not check for existence of keyfile, as the private key is allowed
+    # to be in the certfile
+  end # if generate_certs
+
+  if node[:neutron][:ssl][:cert_required] and !::File.exists? node[:neutron][:ssl][:ca_certs]
+    message = "Certificate CA \"#{node[:neutron][:ssl][:ca_certs]}\" is not present."
+    Chef::Log.fatal(message)
+    raise message
+  end
+end
+
+include_recipe "neutron::common_config"
 
 # XXX this is no different from the file provided in the package, but
 # since we used to have a configured template here, we need to make sure

--- a/chef/roles/neutron-server.rb
+++ b/chef/roles/neutron-server.rb
@@ -5,5 +5,3 @@ run_list(
   "recipe[neutron::server]",
   "recipe[neutron::monitor]"
 )
-
-override_attributes "neutron" => { "neutron_server" => "true" }


### PR DESCRIPTION
They where only executed on the server anyway. This also gets us rid of
the the "neutron_server" attribute.