### PR TITLE
Make sure to not write an empty database setting to neutron.conf

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -626,7 +626,9 @@ insecure = <%= @keystone_settings['insecure'] %>
 # Replace 127.0.0.1 above with the IP address of the database used by the
 # main neutron server. (Leave it as is if the database runs on this host.)
 # connection = sqlite://
+<% unless @sql_connection.nil? || @sql_connection.empty? -%>
 connection = <%= @sql_connection %>
+<% end -%>
 # NOTE: In deployment the [database] section and its connection attribute may
 # be set in the corresponding core plugin '.ini' file. However, it is suggested
 # to put the [database] section and its connection attribute in this


### PR DESCRIPTION
This confuses the metadata agent and causes it to fail on startup.