### PR TITLE
Use auth_uri/identity_uri

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -615,10 +615,14 @@ root_helper=sudo <%=@rootwrap_bin%> /etc/neutron/rootwrap.conf
 # ===========  end of items for agent management extension =====
 
 [keystone_authtoken]
-auth_uri = <%= @keystone_settings['internal_auth_url'] %>
-auth_host = <%= @keystone_settings['internal_url_host'] %>
-auth_port = <%= @keystone_settings['admin_port'] %>
-auth_protocol = <%= @keystone_settings['protocol'] %>
+# Complete public Identity API endpoint (string value)
+auth_uri = <%= @keystone_settings['public_auth_url'] %>
+
+# Complete admin Identity API endpoint. This should specify
+# the unversioned root endpoint e.g. https://localhost:35357/
+# (string value)
+identity_uri = <%= @keystone_settings['admin_auth_url'] %>
+
 admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
 admin_user = <%= @keystone_settings['service_user'] %>
 admin_password = <%= @keystone_settings['service_password'] %>


### PR DESCRIPTION
Properly use the non-deprecated Keystone middleware config settings