### PR TITLE
Do not set nova_ca_certificates_file

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -116,14 +116,12 @@ unless nova[:nova].nil? or nova[:nova][:ssl].nil?
   nova_api_protocol = nova[:nova][:ssl][:enabled] ? "https" : "http"
   keystone_insecure = keystone_settings['insecure'] ? "--insecure" : ""
   nova_insecure = nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]
-  nova_ssl_cacerts = nova[:nova][:ssl][:ca_certs] unless nova_insecure
 
   nova_admin_tenant_id = %x[keystone --os_username '#{keystone_settings['admin_user']}' --os_password '#{keystone_settings['admin_password']}' --os_tenant_name '#{keystone_settings['admin_tenant']}' --os_auth_url '#{keystone_settings['internal_auth_url']}' --os_region_name '#{keystone_settings['endpoint_region']}' #{keystone_insecure} tenant-get '#{keystone_settings['service_tenant']}' | awk '/id/  { print $4 }'].chomp
 
   nova_notify = {
     :nova_url => "#{nova_api_protocol}://#{nova_api_host}:#{nova[:nova][:ports][:api]}/v2",
     :nova_insecure => nova_insecure,
-    :nova_ssl_cacerts => nova_ssl_cacerts,
     :nova_admin_username => nova[:nova][:service_user],
     :nova_admin_tenant_id => nova_admin_tenant_id,
     :nova_admin_password => nova[:nova][:service_password]

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -302,9 +302,6 @@ nova_admin_auth_url = <%= @keystone_settings['internal_auth_url'] %>
 
 # CA file for novaclient to verify server certificates
 # nova_ca_certificates_file =
-<% if @nova_ssl_cacerts -%>
-nova_ca_certificates_file = <%= @nova_ssl_cacerts %>
-<% end -%>
 
 # Boolean to control ignoring SSL errors on the nova url
 # nova_api_insecure = False


### PR DESCRIPTION
Everywhere else, we rely on the admins to either properly install their
CA certificate system-wide, or to use the insecure options in the
barclamps.