### PR TITLE
Enables metadata network

### DIFF
--- a/chef/cookbooks/neutron/recipes/l3.rb
+++ b/chef/cookbooks/neutron/recipes/l3.rb
@@ -156,7 +156,7 @@ template "/etc/neutron/dhcp_agent.ini" do
     :dhcp_driver => "neutron.agent.linux.dhcp.Dnsmasq",
     :dhcp_domain => node[:neutron][:dhcp_domain],
     :enable_isolated_metadata => "True",
-    :enable_metadata_network => "False",
+    :enable_metadata_network => "True",
     :nameservers => dns_list
   )
 end


### PR DESCRIPTION
This allows the VMs to have custom routes to neutron metadata server.
It will enable the metadata server to accessed from inside the VMs.