### PR TITLE
HA: Set Optional  ordering for Neutron startup

### DIFF
--- a/chef/cookbooks/neutron/recipes/l3_ha.rb
+++ b/chef/cookbooks/neutron/recipes/l3_ha.rb
@@ -139,15 +139,10 @@ pacemaker_primitive ha_tool_primitive_name do
   only_if { use_l3_agent && CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
-ha_tool_ordering = "#{agents_clone_name} #{ha_tool_primitive_name}"
-if node.roles.include?("neutron-server") && node[:neutron][:ha][:server][:enabled]
-  ha_tool_ordering = "g-haproxy cl-neutron-server #{agents_clone_name} #{ha_tool_primitive_name}"
-end
-
-pacemaker_order "o-neutron-ha-tool" do
-  ordering ha_tool_ordering
+crowbar_pacemaker_order_only_existing "o-#{ha_tool_primitive_name}" do
+  ordering [ "g-haproxy", "cl-neutron-server", agents_clone_name, ha_tool_primitive_name ]
   score "Mandatory"
-  action [ :create ]
+  action :create
   only_if { use_l3_agent && CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 

--- a/chef/cookbooks/neutron/recipes/server_ha.rb
+++ b/chef/cookbooks/neutron/recipes/server_ha.rb
@@ -44,4 +44,11 @@ pacemaker_clone "cl-#{primitive_name}" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
+crowbar_pacemaker_order_only_existing "o-cl-#{primitive_name}" do
+  ordering [ "postgresql", "rabbitmq", "cl-keystone", "cl-#{primitive_name}" ]
+  score "Optional"
+  action :create
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
 crowbar_pacemaker_sync_mark "create-neutron_ha_resources"


### PR DESCRIPTION
Neutron depends on Keystone and RabbitMQ to be started first