### PR TITLE
Use SSL to talk to nova-metadata when SSL is enabled for nova

### DIFF
--- a/chef/cookbooks/neutron/recipes/l3.rb
+++ b/chef/cookbooks/neutron/recipes/l3.rb
@@ -171,9 +171,6 @@ if novas.length > 0
 else
   nova = node
 end
-# we use an IP address here, and not nova[:fqdn] because nova-metadata doesn't use SSL
-# and because it listens on this specific IP address only (so we don't want to use a name
-# that could resolve to 127.0.0.1).
 metadata_host = CrowbarHelper.get_host_for_admin_url(nova, (nova[:nova][:ha][:enabled] rescue false))
 metadata_port = nova[:nova][:ports][:metadata] rescue 8775
 metadata_protocol = (nova[:nova][:ssl][:enabled] ? "https" : "http") rescue "http"

--- a/chef/cookbooks/neutron/recipes/l3.rb
+++ b/chef/cookbooks/neutron/recipes/l3.rb
@@ -175,7 +175,7 @@ end
 # and because it listens on this specific IP address only (so we don't want to use a name
 # that could resolve to 127.0.0.1).
 metadata_host = CrowbarHelper.get_host_for_admin_url(nova, (nova[:nova][:ha][:enabled] rescue false))
-metadata_port = "8775"
+metadata_port = nova[:nova][:ports][:metadata] rescue 8775
 metadata_protocol = (nova[:nova][:ssl][:enabled] ? "https" : "http") rescue "http"
 metadata_insecure = (nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]) rescue false
 metadata_proxy_shared_secret = (nova[:nova][:neutron_metadata_proxy_shared_secret] rescue '')

--- a/chef/cookbooks/neutron/recipes/l3.rb
+++ b/chef/cookbooks/neutron/recipes/l3.rb
@@ -176,6 +176,8 @@ end
 # that could resolve to 127.0.0.1).
 metadata_host = CrowbarHelper.get_host_for_admin_url(nova, (nova[:nova][:ha][:enabled] rescue false))
 metadata_port = "8775"
+metadata_protocol = (nova[:nova][:ssl][:enabled] ? "https" : "http") rescue "http"
+metadata_insecure = (nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]) rescue false
 metadata_proxy_shared_secret = (nova[:nova][:neutron_metadata_proxy_shared_secret] rescue '')
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
@@ -192,6 +194,8 @@ template "/etc/neutron/metadata_agent.ini" do
     :neutron_insecure => node[:neutron][:ssl][:insecure],
     :nova_metadata_host => metadata_host,
     :nova_metadata_port => metadata_port,
+    :nova_metadata_protocol => metadata_protocol,
+    :nova_metadata_insecure => metadata_insecure,
     :metadata_proxy_shared_secret => metadata_proxy_shared_secret
   )
 end

--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -21,6 +21,7 @@ admin_password = <%= @keystone_settings['service_password'] %>
 
 # Network service endpoint type to pull from the keystone catalog
 # endpoint_type = adminURL
+endpoint_type = internalURL
 
 # IP address used by Nova metadata server
 # nova_metadata_ip = 127.0.0.1

--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -31,11 +31,11 @@ nova_metadata_ip = <%= @nova_metadata_host %>
 nova_metadata_port = <%= @nova_metadata_port %>
 
 # Which protocol to use for requests to Nova metadata server, http or https
-# nova_metadata_protocol = http
+nova_metadata_protocol = <%= @nova_metadata_protocol %>
 
 # Whether insecure SSL connection should be accepted for Nova metadata server
 # requests
-# nova_metadata_insecure = False
+nova_metadata_insecure = <%= @nova_metadata_insecure ? "True" : "False" %>
 
 # Client certificate for nova api, needed when nova api requires client
 # certificates


### PR DESCRIPTION
This depends on https://github.com/crowbar/barclamp-nova/pull/438