### PR TITLE
use lower MTU value for GRE tunnels (bnc#917328)

### DIFF
--- a/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/dhcp_agent.ini.erb
@@ -70,7 +70,7 @@ enable_metadata_network = <%= @enable_metadata_network %>
 dhcp_domain = <%= @dhcp_domain %>
 
 # Override the default dnsmasq settings with this file
-# dnsmasq_config_file =
+dnsmasq_config_file = /etc/neutron/dnsmasq-neutron.conf
 
 # Comma-separated list of DNS servers which will be used by dnsmasq
 # as forwarders.

--- a/chef/cookbooks/neutron/templates/default/dnsmasq-neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/dnsmasq-neutron.conf.erb
@@ -1,0 +1,4 @@
+# this file is managed by chef to give extra options to dnsmasq
+<% if @force_mtu -%>
+dhcp-option-force=26,<%= @force_mtu.to_s %>
+<% end -%>


### PR DESCRIPTION
this avoids fragmentation as per
http://docs.openstack.org/admin-guide-cloud/content/openvswitch_plugin.html

and avoids networking problems with SLE12 compute hosts and GRE
https://bugzilla.suse.com/show_bug.cgi?id=917328