### PR TITLE
Enable L2 population mechanism driver

### DIFF
--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -170,7 +170,7 @@ case node[:neutron][:networking_plugin]
 when 'ml2'
   ml2_type_drivers = node[:neutron][:ml2_type_drivers]
   ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup.push("hyperv")
-  if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
+  if node[:neutron][:use_l2pop] && (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"))
     ml2_mechanism_drivers.push("l2population")
   end
 

--- a/chef/cookbooks/neutron/recipes/server.rb
+++ b/chef/cookbooks/neutron/recipes/server.rb
@@ -168,13 +168,19 @@ tenant_network_types = [[node[:neutron][:ml2_type_drivers_default_tenant_network
 
 case node[:neutron][:networking_plugin]
 when 'ml2'
+  ml2_type_drivers = node[:neutron][:ml2_type_drivers]
+  ml2_mechanism_drivers = node[:neutron][:ml2_mechanism_drivers].dup.push("hyperv")
+  if ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")
+    ml2_mechanism_drivers.push("l2population")
+  end
+
   template plugin_cfg_path do
     source "ml2_conf.ini.erb"
     owner "root"
     group node[:neutron][:platform][:group]
     mode "0640"
     variables(
-      :ml2_mechanism_drivers => node[:neutron][:ml2_mechanism_drivers],
+      :ml2_mechanism_drivers => ml2_mechanism_drivers,
       :ml2_type_drivers => node[:neutron][:ml2_type_drivers],
       :tenant_network_types => tenant_network_types,
       :vlan_start => vlan_start,

--- a/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
@@ -74,7 +74,7 @@ local_ip = <%= node.address("os_sdn").addr %>
 # the use of broadcast emulation (multicast will be turned off if kernel and
 # iproute2 supports unicast flooding - requires 3.11 kernel and iproute2 3.10)
 # l2_population = False
-<% if @ml2_type_drivers.include?("vxlan") -%>
+<% if @use_l2pop -%>
 l2_population = True
 <% end -%>
 

--- a/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
@@ -74,6 +74,9 @@ local_ip = <%= node.address("os_sdn").addr %>
 # the use of broadcast emulation (multicast will be turned off if kernel and
 # iproute2 supports unicast flooding - requires 3.11 kernel and iproute2 3.10)
 # l2_population = False
+<% if @ml2_type_drivers.include?("vxlan") -%>
+l2_population = True
+<% end -%>
 
 [agent]
 # Agent's polling interval in seconds

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -22,7 +22,7 @@ tenant_network_types = <%= @tenant_network_types.join(",") %>
 # Example: mechanism_drivers = cisco,logger
 # Example: mechanism_drivers = openvswitch,brocade
 # Example: mechanism_drivers = linuxbridge,brocade
-mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>,hyperv
+mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 
 # (ListOpt) Ordered list of extension driver entrypoints
 # to be loaded from the neutron.ml2.extension_drivers namespace.

--- a/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
@@ -150,7 +150,7 @@ tunnel_types = <%= @tunnel_types.join(",") %>
 # optimize tunnel management.
 #
 # l2_population = False
-<% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
+<% if @use_l2pop -%>
 l2_population = True
 <% end -%>
 
@@ -158,7 +158,7 @@ l2_population = True
 # population ML2 MechanismDriver.
 #
 # arp_responder = False
-<% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
+<% if @use_l2pop -%>
 arp_responder = True
 <% end -%>
 

--- a/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
@@ -150,11 +150,17 @@ tunnel_types = <%= @tunnel_types.join(",") %>
 # optimize tunnel management.
 #
 # l2_population = False
+<% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
+l2_population = True
+<% end -%>
 
 # Enable local ARP responder. Requires OVS 2.1. This is only used by the l2
 # population ML2 MechanismDriver.
 #
 # arp_responder = False
+<% if @ml2_type_drivers.include?("gre") || @ml2_type_drivers.include?("vxlan") -%>
+arp_responder = True
+<% end -%>
 
 # (BoolOpt) Set or un-set the don't fragment (DF) bit on outgoing IP packet
 # carrying GRE/VXLAN tunnel. The default value is True.

--- a/chef/data_bags/crowbar/bc-template-neutron.json
+++ b/chef/data_bags/crowbar/bc-template-neutron.json
@@ -25,6 +25,7 @@
       "verbose": true,
       "dhcp_domain": "openstack.local",
       "use_lbaas": true,
+      "use_l2pop": true,
       "networking_plugin": "ml2",
       "ml2_mechanism_drivers": ["openvswitch"],
       "ml2_type_drivers": ["gre"],
@@ -79,7 +80,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 24,
+      "schema-revision": 25,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-l3": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-neutron.schema
+++ b/chef/data_bags/crowbar/bc-template-neutron.schema
@@ -16,6 +16,7 @@
                     "gitrepo": { "type": "str", "required": true },
                     "dhcp_domain": { "type": "str", "required": true },
                     "use_lbaas": { "type": "bool", "required": true },
+                    "use_l2pop": { "type": "bool", "required": true },
                     "networking_plugin": { "type": "str", "required": true },
                     "ml2_mechanism_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "ml2_type_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },

--- a/chef/data_bags/crowbar/migrate/neutron/025_use_l2pop.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/025_use_l2pop.rb
@@ -1,0 +1,13 @@
+def upgrade ta, td, a, d
+  # Explicitly disable on upgrade as this can create some temporary networking
+  # outage on existing deployments
+  a['use_l2pop'] = false
+
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('use_l2pop')
+
+  return a, d
+end

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -229,6 +229,12 @@ class NeutronService < PacemakerServiceObject
       validation_error("The 'openvswitch' and 'linuxbridge' mechanism drivers can't be used in parallel. Only select one of them")
     end
 
+    if proposal["attributes"]["neutron"]["use_l2pop"]
+      unless ml2_type_drivers.include?('gre') || ml2_type_drivers.include?('vxlan')
+        validation_error("L2 population requires GRE and/or VXLAN")
+      end
+    end
+
     super
   end
 


### PR DESCRIPTION
This is only possible when VXLAN or GRE is used.

For more details about L2 population, see
http://docs.openstack.org/admin-guide-cloud/content/ml2_l2pop_scenarios.html
and https://wiki.openstack.org/wiki/L2population

This comes on top of https://github.com/crowbar/barclamp-neutron/pull/206