### PR TITLE
Add support for DVR

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -143,17 +143,17 @@ else
   }
 end
 
-default[:neutron][:ha][:l3][:enabled] = false
-default[:neutron][:ha][:l3][:l3_ra] = "lsb:#{node[:neutron][:platform][:l3_agent_name]}"
-default[:neutron][:ha][:l3][:lbaas_ra] = "lsb:#{node[:neutron][:platform][:lbaas_agent_name]}"
-default[:neutron][:ha][:l3][:dhcp_ra] = "lsb:#{node[:neutron][:platform][:dhcp_agent_name]}"
-default[:neutron][:ha][:l3][:metadata_ra] = "lsb:#{node[:neutron][:platform][:metadata_agent_name]}"
-default[:neutron][:ha][:l3][:metering_ra] = "lsb:#{node[:neutron][:platform][:metering_agent_name]}"
-default[:neutron][:ha][:l3][:openvswitch_ra] = "lsb:#{node[:neutron][:platform][:ovs_agent_name]}"
-default[:neutron][:ha][:l3][:cisco_ra] = "lsb:#{node[:neutron][:ha][:l3][:openvswitch_ra]}"
-default[:neutron][:ha][:l3][:linuxbridge_ra] = "lsb:#{node[:neutron][:platform][:lb_agent_name]}"
-default[:neutron][:ha][:l3][:ha_tool_ra] = "ocf:openstack:neutron-ha-tool"
-default[:neutron][:ha][:l3][:op][:monitor][:interval] = "10s"
+default[:neutron][:ha][:network][:enabled] = false
+default[:neutron][:ha][:network][:l3_ra] = "lsb:#{node[:neutron][:platform][:l3_agent_name]}"
+default[:neutron][:ha][:network][:lbaas_ra] = "lsb:#{node[:neutron][:platform][:lbaas_agent_name]}"
+default[:neutron][:ha][:network][:dhcp_ra] = "lsb:#{node[:neutron][:platform][:dhcp_agent_name]}"
+default[:neutron][:ha][:network][:metadata_ra] = "lsb:#{node[:neutron][:platform][:metadata_agent_name]}"
+default[:neutron][:ha][:network][:metering_ra] = "lsb:#{node[:neutron][:platform][:metering_agent_name]}"
+default[:neutron][:ha][:network][:openvswitch_ra] = "lsb:#{node[:neutron][:platform][:ovs_agent_name]}"
+default[:neutron][:ha][:network][:cisco_ra] = "lsb:#{node[:neutron][:ha][:network][:openvswitch_ra]}"
+default[:neutron][:ha][:network][:linuxbridge_ra] = "lsb:#{node[:neutron][:platform][:lb_agent_name]}"
+default[:neutron][:ha][:network][:ha_tool_ra] = "ocf:openstack:neutron-ha-tool"
+default[:neutron][:ha][:network][:op][:monitor][:interval] = "10s"
 default[:neutron][:ha][:server][:enabled] = false
 default[:neutron][:ha][:server][:server_ra] = "lsb:#{node[:neutron][:platform][:service_name]}"
 default[:neutron][:ha][:server][:op][:monitor][:interval] = "10s"

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -312,12 +312,12 @@ end
 
 include_recipe "neutron::common_config"
 
-neutron_l3_ha = node.roles.include?("neutron-l3") && node[:neutron][:ha][:l3][:enabled]
+neutron_network_ha = node.roles.include?("neutron-network") && node[:neutron][:ha][:network][:enabled]
 
 service neutron_agent do
   supports :status => true, :restart => true
   action [:enable, :start]
   subscribes :restart, resources("template[#{agent_config_path}]")
   subscribes :restart, resources("template[/etc/neutron/neutron.conf]")
-  provider Chef::Provider::CrowbarPacemakerService if neutron_l3_ha
+  provider Chef::Provider::CrowbarPacemakerService if neutron_network_ha
 end

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -130,7 +130,8 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       variables(
         :ml2_type_drivers => ml2_type_drivers,
         :tunnel_types => ml2_type_drivers.select { |t| ["vxlan", "gre"].include?(t) },
-        :use_l2pop => neutron[:neutron][:use_l2pop] && (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan"))
+        :use_l2pop => neutron[:neutron][:use_l2pop] && (ml2_type_drivers.include?("gre") || ml2_type_drivers.include?("vxlan")),
+        :dvr_enabled => neutron[:neutron][:use_dvr]
       )
     end
   when ml2_mech_drivers.include?("linuxbridge")
@@ -312,7 +313,7 @@ end
 
 include_recipe "neutron::common_config"
 
-neutron_network_ha = node.roles.include?("neutron-network") && node[:neutron][:ha][:network][:enabled]
+neutron_network_ha = node.roles.include?("neutron-network") && neutron[:neutron][:ha][:network][:enabled]
 
 service neutron_agent do
   supports :status => true, :restart => true
@@ -320,4 +321,56 @@ service neutron_agent do
   subscribes :restart, resources("template[#{agent_config_path}]")
   subscribes :restart, resources("template[/etc/neutron/neutron.conf]")
   provider Chef::Provider::CrowbarPacemakerService if neutron_network_ha
+end
+
+# Note: if vmware, we do not reach this code
+
+if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
+  unless neutron[:neutron][:use_gitrepo]
+    package node[:neutron][:platform][:l3_agent_pkg]
+  else
+    link_service "neutron-l3-agent" do
+      virtualenv venv_path
+      bin_name "neutron-l3-agent --config-dir /etc/neutron/"
+    end
+  end
+
+  ml2_mech_drivers = neutron[:neutron][:ml2_mechanism_drivers]
+  case
+  when ml2_mech_drivers.include?("openvswitch")
+    interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
+    external_network_bridge = "br-public"
+  when ml2_mech_drivers.include?("linuxbridge")
+    interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
+    external_network_bridge = ""
+  end
+
+  template "/etc/neutron/l3_agent.ini" do
+    source "l3_agent.ini.erb"
+    owner "root"
+    group node[:neutron][:platform][:group]
+    mode "0640"
+    variables(
+      :debug => neutron[:neutron][:debug],
+      :interface_driver => interface_driver,
+      :use_namespaces => "True",
+      :handle_internal_only_routers => "True",
+      :metadata_port => 9697,
+      :send_arp_for_ha => 3,
+      :periodic_interval => 40,
+      :periodic_fuzzy_delay => 5,
+      :external_network_bridge => external_network_bridge,
+      :dvr_enabled => neutron[:neutron][:use_dvr],
+      :dvr_mode => node.roles.include?("neutron-network") ? "dvr_snat" : "dvr"
+    )
+  end
+
+  service node[:neutron][:platform][:l3_agent_name] do
+    service_name "neutron-l3-agent" if neutron[:neutron][:use_gitrepo]
+    supports :status => true, :restart => true
+    action [:enable, :start]
+    subscribes :restart, resources("template[/etc/neutron/neutron.conf]")
+    subscribes :restart, resources("template[/etc/neutron/l3_agent.ini]")
+    provider Chef::Provider::CrowbarPacemakerService if neutron_network_ha
+  end
 end

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -242,14 +242,14 @@ if neutron[:neutron][:networking_plugin] == "ml2"
 
   case
   when ml2_mech_drivers.include?("openvswitch")
-    neutron_agent = neutron[:neutron][:platform][:ovs_agent_name]
-    neutron_agent_pkg = neutron[:neutron][:platform][:ovs_agent_pkg]
+    neutron_agent = node[:neutron][:platform][:ovs_agent_name]
+    neutron_agent_pkg = node[:neutron][:platform][:ovs_agent_pkg]
     agent_config_path = "/etc/neutron/plugins/openvswitch/ovs_neutron_plugin.ini"
     interface_driver = "neutron.agent.linux.interface.OVSInterfaceDriver"
     external_network_bridge = "br-public"
   when ml2_mech_drivers.include?("linuxbridge")
-    neutron_agent = neutron[:neutron][:platform][:lb_agent_name]
-    neutron_agent_pkg = neutron[:neutron][:platform][:lb_agent_pkg]
+    neutron_agent = node[:neutron][:platform][:lb_agent_name]
+    neutron_agent_pkg = node[:neutron][:platform][:lb_agent_pkg]
     agent_config_path = "/etc/neutron/plugins/linuxbridge/linuxbridge_conf.ini"
     interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
     external_network_bridge = ""
@@ -277,7 +277,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     directory "/etc/neutron/plugins/openvswitch/" do
       mode 00755
       owner "root"
-      group neutron[:neutron][:platform][:group]
+      group node[:neutron][:platform][:group]
       action :create
       recursive true
       not_if { node[:platform] == "suse" }
@@ -287,7 +287,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       cookbook "neutron"
       source "ovs_neutron_plugin.ini.erb"
       owner "root"
-      group neutron[:neutron][:platform][:group]
+      group node[:neutron][:platform][:group]
       mode "0640"
       variables(
         :ml2_type_drivers => ml2_type_drivers,
@@ -300,7 +300,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     directory "/etc/neutron/plugins/linuxbridge/" do
       mode 00755
       owner "root"
-      group neutron[:neutron][:platform][:group]
+      group node[:neutron][:platform][:group]
       action :create
       recursive true
       not_if { node[:platform] == "suse" }
@@ -310,7 +310,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
       cookbook "neutron"
       source "linuxbridge_conf.ini.erb"
       owner "root"
-      group neutron[:neutron][:platform][:group]
+      group node[:neutron][:platform][:group]
       mode "0640"
       variables(
         :physnet => (node[:crowbar_wall][:network][:nets][:nova_fixed].first rescue nil),

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -231,11 +231,11 @@ else
   end
 end
 
+neutron_network_ha = node.roles.include?("neutron-network") && neutron[:neutron][:ha][:network][:enabled]
+
 # ML2 configuration: L2 agent and L3 agent
 if neutron[:neutron][:networking_plugin] == "ml2"
   include_recipe "neutron::common_config"
-
-  neutron_network_ha = node.roles.include?("neutron-network") && neutron[:neutron][:ha][:network][:enabled]
 
   ml2_mech_drivers = neutron[:neutron][:ml2_mechanism_drivers]
   ml2_type_drivers = neutron[:neutron][:ml2_type_drivers]
@@ -371,6 +371,61 @@ if neutron[:neutron][:networking_plugin] == "ml2"
   end
 end
 
+# Metadata agent
+unless neutron[:neutron][:use_gitrepo]
+  package node[:neutron][:platform][:metadata_agent_pkg]
+else
+  link_service "neutron-metadata-agent" do
+    virtualenv venv_path
+    bin_name "neutron-metadata-agent --config-dir /etc/neutron/ --config-file /etc/neutron/metadata_agent.ini"
+  end
+end
+
+#TODO: nova should depend on neutron, but neutron also depends on nova
+# so we have to do something like this
+novas = search(:node, "roles:nova-multi-controller") || []
+if novas.length > 0
+  nova = novas[0]
+  nova = node if nova.name == node.name
+else
+  nova = node
+end
+metadata_host = CrowbarHelper.get_host_for_admin_url(nova, (nova[:nova][:ha][:enabled] rescue false))
+metadata_port = nova[:nova][:ports][:metadata] rescue 8775
+metadata_protocol = (nova[:nova][:ssl][:enabled] ? "https" : "http") rescue "http"
+metadata_insecure = (nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]) rescue false
+metadata_proxy_shared_secret = (nova[:nova][:neutron_metadata_proxy_shared_secret] rescue '')
+
+keystone_settings = KeystoneHelper.keystone_settings(neutron, @cookbook_name)
+
+template "/etc/neutron/metadata_agent.ini" do
+  source "metadata_agent.ini.erb"
+  owner "root"
+  group node[:neutron][:platform][:group]
+  mode "0640"
+  variables(
+    :debug => neutron[:neutron][:debug],
+    :keystone_settings => keystone_settings,
+    :auth_region => keystone_settings['endpoint_region'],
+    :neutron_insecure => neutron[:neutron][:ssl][:insecure],
+    :nova_metadata_host => metadata_host,
+    :nova_metadata_port => metadata_port,
+    :nova_metadata_protocol => metadata_protocol,
+    :nova_metadata_insecure => metadata_insecure,
+    :metadata_proxy_shared_secret => metadata_proxy_shared_secret
+  )
+end
+
+service node[:neutron][:platform][:metadata_agent_name] do
+  service_name "neutron-metadata-agent" if neutron[:neutron][:use_gitrepo]
+  supports :status => true, :restart => true
+  action [:enable, :start]
+  subscribes :restart, resources("template[/etc/neutron/neutron.conf]")
+  subscribes :restart, resources("template[/etc/neutron/metadata_agent.ini]")
+  provider Chef::Provider::CrowbarPacemakerService if neutron_network_ha
+end
+
+# VMware specific code
 if neutron[:neutron][:networking_plugin] == "vmware"
   include_recipe "neutron::vmware_support"
   # We don't need anything more installed or configured on

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -174,7 +174,7 @@ template "/etc/neutron/neutron.conf" do
       :service_plugins => service_plugins,
       :rootwrap_bin =>  node[:neutron][:rootwrap],
       :use_namespaces => true,
-      :allow_overlapping_ips => node[:neutron][:allow_overlapping_ips],
+      :allow_overlapping_ips => neutron[:neutron][:allow_overlapping_ips],
       :dvr_enabled => neutron[:neutron][:use_dvr]
     }.merge(nova_notify))
 end

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -174,7 +174,8 @@ template "/etc/neutron/neutron.conf" do
       :service_plugins => service_plugins,
       :rootwrap_bin =>  node[:neutron][:rootwrap],
       :use_namespaces => true,
-      :allow_overlapping_ips => node[:neutron][:allow_overlapping_ips]
+      :allow_overlapping_ips => node[:neutron][:allow_overlapping_ips],
+      :dvr_enabled => neutron[:neutron][:use_dvr]
     }.merge(nova_notify))
 end
 

--- a/chef/cookbooks/neutron/recipes/network_agents.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents.rb
@@ -212,7 +212,7 @@ template "/etc/neutron/metadata_agent.ini" do
   )
 end
 
-ha_enabled = node[:neutron][:ha][:l3][:enabled]
+ha_enabled = node[:neutron][:ha][:network][:enabled]
 
 unless node[:neutron][:networking_plugin] == "vmware"
   service node[:neutron][:platform][:l3_agent_name] do
@@ -280,8 +280,8 @@ service node[:neutron][:platform][:metadata_agent_name] do
 end
 
 if ha_enabled
-  log "HA support for neutron-l3-agent is enabled"
-  include_recipe "neutron::l3_ha"
+  log "HA support for neutron agents is enabled"
+  include_recipe "neutron::network_agents_ha"
 else
-  log "HA support for neutron-l3-agent is disabled"
+  log "HA support for neutron agents is disabled"
 end

--- a/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
@@ -102,6 +102,9 @@ router_delete_namespaces = True
 #   DVR. This mode must be used for an L3 agent running on a centralized
 #   node (or in single-host deployments, e.g. devstack).
 # agent_mode = legacy
+<% if @dvr_enabled -%>
+agent_mode = <%= @dvr_mode %>
+<% end -%>
 
 # Location to store keepalived and all HA configurations
 # ha_confs_path = $state_path/ha_confs

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -10,6 +10,9 @@ verbose = <%= @verbose ? "True" : "False" %>
 # value is "False" to support legacy mode (centralized) routers.
 #
 # router_distributed = False
+<% if @dvr_enabled -%>
+router_distributed = True
+<% end -%>
 #
 # ===========End Global Config Option for Distributed L3 Router===============
 

--- a/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
@@ -171,6 +171,9 @@ arp_responder = True
 # for distributed virtual routing.
 #
 # enable_distributed_routing = False
+<% if @dvr_enabled -%>
+enable_distributed_routing = True
+<% end -%>
 
 [securitygroup]
 # Firewall driver for realizing neutron security group function.

--- a/chef/data_bags/crowbar/bc-template-neutron.json
+++ b/chef/data_bags/crowbar/bc-template-neutron.json
@@ -80,19 +80,19 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 25,
+      "schema-revision": 26,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
-        "neutron-l3": [ "readying", "ready", "applying" ]
+        "neutron-network": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [
          ["neutron-server" ],
-         ["neutron-l3" ]
+         ["neutron-network" ]
       ],
       "element_run_list_order": {
         "neutron-server": 94,
-        "neutron-l3": 95
+        "neutron-network": 95
       },
       "config": {
         "environment": "neutron-config-base",

--- a/chef/data_bags/crowbar/bc-template-neutron.json
+++ b/chef/data_bags/crowbar/bc-template-neutron.json
@@ -26,6 +26,7 @@
       "dhcp_domain": "openstack.local",
       "use_lbaas": true,
       "use_l2pop": true,
+      "use_dvr": false,
       "networking_plugin": "ml2",
       "ml2_mechanism_drivers": ["openvswitch"],
       "ml2_type_drivers": ["gre"],
@@ -80,7 +81,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 26,
+      "schema-revision": 27,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-neutron.schema
+++ b/chef/data_bags/crowbar/bc-template-neutron.schema
@@ -17,6 +17,7 @@
                     "dhcp_domain": { "type": "str", "required": true },
                     "use_lbaas": { "type": "bool", "required": true },
                     "use_l2pop": { "type": "bool", "required": true },
+                    "use_dvr": { "type": "bool", "required": true },
                     "networking_plugin": { "type": "str", "required": true },
                     "ml2_mechanism_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "ml2_type_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },

--- a/chef/data_bags/crowbar/migrate/neutron/026_rename_l3_role.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/026_rename_l3_role.rb
@@ -1,0 +1,44 @@
+def upgrade ta, td, a, d
+  d['elements']['neutron-network'] = d['elements']['neutron-l3']
+  d['elements'].delete('neutron-l3')
+
+  d['element_states'] = td['element_states']
+  d['element_order'] = td['element_order']
+  d['element_run_list_order'] = td['element_run_list_order']
+
+  # Make sure that all nodes that have the "neutron-l3" role
+  # in their run_list are migrated to "neutron-network"
+  nodes = NodeObject.find('roles:neutron-l3')
+  nodes.each do |node|
+    node.add_to_run_list('neutron-network',
+                         td['element_run_list_order']['neutron-network'],
+                         td['element_states']['neutron-network'])
+    node.delete_from_run_list('neutron-l3')
+    node.save
+  end
+
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  d['elements']['neutron-l3'] = d['elements']['neutron-network']
+  d['elements'].delete('neutron-network')
+
+  d['element_states'] = td['element_states']
+  d['element_order'] = td['element_order']
+  d['element_run_list_order'] = td['element_run_list_order']
+
+  # Make sure that all nodes that have the "neutron-network" role
+  # in their run_list are migrated to "neutron-l3"
+  nodes = NodeObject.find('roles:neutron-network')
+  nodes.each do |node|
+    node.add_to_run_list('neutron-l3',
+                         td['element_run_list_order']['neutron-l3'],
+                         td['element_states']['neutron-l3'])
+    node.delete_from_run_list('neutron-network')
+    node.save
+  end
+
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/migrate/neutron/027_use_dvr.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/027_use_dvr.rb
@@ -1,0 +1,11 @@
+def upgrade ta, td, a, d
+  a['use_dvr'] = ta['use_dvr']
+
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('use_dvr')
+
+  return a, d
+end

--- a/chef/roles/neutron-l3.rb
+++ b/chef/roles/neutron-l3.rb
@@ -1,6 +1,0 @@
-name "neutron-l3"
-description "Neutron L3"
-
-run_list(
-  "recipe[neutron::l3]"
-)

--- a/chef/roles/neutron-network.rb
+++ b/chef/roles/neutron-network.rb
@@ -1,0 +1,6 @@
+name "neutron-network"
+description "Neutron Network Agents"
+
+run_list(
+  "recipe[neutron::network_agents]"
+)

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -244,6 +244,13 @@ class NeutronService < PacemakerServiceObject
       if !proposal["attributes"]["neutron"]["use_l2pop"]
         validation_error("DVR requires L2 population")
       end
+
+      unless proposal["deployment"]["neutron"]["elements"].fetch("neutron-network", []).empty? 
+        network_node = proposal["deployment"]["neutron"]["elements"]["neutron-network"][0]
+        if is_cluster? network_node
+          validation_error("DVR is not compatible with High Availability for neutron-network")
+        end
+      end
     end
 
     super

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -53,7 +53,7 @@ class NeutronService < PacemakerServiceObject
           },
           "cluster" => true
         },
-        "neutron-l3" => {
+        "neutron-network" => {
           "unique" => false,
           "count" => 1,
           "admin" => false,
@@ -97,7 +97,7 @@ class NeutronService < PacemakerServiceObject
 
     base["deployment"]["neutron"]["elements"] = {
         "neutron-server" => [ controller_node[:fqdn] ],
-        "neutron-l3" => network_nodes.map { |x| x[:fqdn] }
+        "neutron-network" => network_nodes.map { |x| x[:fqdn] }
     } unless nodes.nil? or nodes.length ==0
 
     base["attributes"]["neutron"]["service_password"] = random_password
@@ -152,7 +152,7 @@ class NeutronService < PacemakerServiceObject
 
   def validate_proposal_after_save proposal
     validate_one_for_role proposal, "neutron-server"
-    validate_at_least_n_for_role proposal, "neutron-l3", 1
+    validate_at_least_n_for_role proposal, "neutron-network", 1
 
     if proposal["attributes"][@bc_name]["use_gitrepo"]
       validate_dep_proposal_is_active "git", proposal["attributes"][@bc_name]["git_instance"]
@@ -249,13 +249,13 @@ class NeutronService < PacemakerServiceObject
     end
 
     server_elements, server_nodes, server_ha_enabled = role_expand_elements(role, "neutron-server")
-    l3_elements, l3_nodes, l3_ha_enabled = role_expand_elements(role, "neutron-l3")
+    network_elements, network_nodes, network_ha_enabled = role_expand_elements(role, "neutron-network")
 
     vip_networks = ["admin", "public"]
 
     dirty = false
     dirty = prepare_role_for_ha_with_haproxy(role, ["neutron", "ha", "server", "enabled"], server_ha_enabled, server_elements, vip_networks)
-    dirty = prepare_role_for_ha(role, ["neutron", "ha", "l3", "enabled"], l3_ha_enabled) || dirty
+    dirty = prepare_role_for_ha(role, ["neutron", "ha", "network", "enabled"], network_ha_enabled) || dirty
     role.save if dirty
 
     # All nodes must have a public IP, even if part of a cluster; otherwise
@@ -266,7 +266,7 @@ class NeutronService < PacemakerServiceObject
 
     allocate_virtual_ips_for_any_cluster_in_networks_and_sync_dns(server_elements, vip_networks)
 
-    l3_nodes.each do |n|
+    network_nodes.each do |n|
       net_svc.allocate_ip "default", "public", "host",n
       # TODO(toabctl): The same code is in the nova barclamp. Should be extracted and reused!
       #                (see crowbar_framework/app/models/nova_service.rb)

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -236,8 +236,9 @@ class NeutronService < PacemakerServiceObject
     end
 
     if proposal["attributes"]["neutron"]["use_dvr"]
-      if !ml2_mechanism_drivers.include?("openvswitch") || !ml2_type_drivers.include?('vxlan')
-        validation_error("DVR can only be used with openvswitch and vxlan")
+      if !ml2_mechanism_drivers.include?("openvswitch") ||
+         (!ml2_type_drivers.include?('gre') && !ml2_type_drivers.include?('vxlan'))
+        validation_error("DVR can only be used with openvswitch and gre/vxlan")
       end
 
       if !proposal["attributes"]["neutron"]["use_l2pop"]

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -235,6 +235,16 @@ class NeutronService < PacemakerServiceObject
       end
     end
 
+    if proposal["attributes"]["neutron"]["use_dvr"]
+      if !ml2_mechanism_drivers.include?("openvswitch") || !ml2_type_drivers.include?('vxlan')
+        validation_error("DVR can only be used with openvswitch and vxlan")
+      end
+
+      if !proposal["attributes"]["neutron"]["use_l2pop"]
+        validation_error("DVR requires L2 population")
+      end
+    end
+
     super
   end
 


### PR DESCRIPTION
**Please note that this PR includes https://github.com/crowbar/barclamp-neutron/pull/209**

*First commit:*
As the L3 agent will also run on compute host, this name makes no sense.
And we really reference such nodes as network nodes, so it makes more
sense this way.

*Second commit:*
DVR stands for Distributed Virtual Routers, see
https://github.com/openstack/neutron-specs/blob/master/specs/juno/neutron-ovs-dvr.rst
https://wiki.openstack.org/wiki/Neutron/DVR

The implementation is loosely based on what's in
https://wiki.openstack.org/wiki/Neutron/DVR/HowTo

For DVR, the L3 agent needs to run not just on the network node, but
also on compute nodes. So the configuration for this has to move to the
common code path.

When using HA, we still setup the L3 agent with pacemaker on the network
nodes, but it's unclear yet if this just works fine.