### PR TITLE
webui: Automatically enable/disable l2pop depending on used types

### DIFF
--- a/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/neutron/application.js
@@ -274,6 +274,9 @@ function ml2_type_drivers_check() {
     $('#vxlan_container').hide();
   }
 
+  var use_l2pop = (values.indexOf("gre") >= 0 || values.indexOf("vxlan") >= 0);
+  $('#proposal_attributes').writeJsonAttribute('use_l2pop', use_l2pop);
+
   if (values.length <= 1) {
     $('#ml2_type_drivers_default_provider_network_container').hide();
     $('#ml2_type_drivers_default_tenant_network_container').hide();

--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -245,7 +245,7 @@ class NeutronService < PacemakerServiceObject
         validation_error("DVR requires L2 population")
       end
 
-      unless proposal["deployment"]["neutron"]["elements"].fetch("neutron-network", []).empty? 
+      unless proposal["deployment"]["neutron"]["elements"].fetch("neutron-network", []).empty?
         network_node = proposal["deployment"]["neutron"]["elements"]["neutron-network"][0]
         if is_cluster? network_node
           validation_error("DVR is not compatible with High Availability for neutron-network")


### PR DESCRIPTION
L2 population doesn't work with vlan-only, so we need to disable it in
that case. But we still want to use it by default when possible, so use
some javascript magic.