### PR TITLE
Fix setup of compute nodes when using linuxbridge

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -238,8 +238,6 @@ neutron_network_ha = node.roles.include?("neutron-network") && neutron[:neutron]
 
 # ML2 configuration: L2 agent and L3 agent
 if neutron[:neutron][:networking_plugin] == "ml2"
-  include_recipe "neutron::common_config"
-
   ml2_mech_drivers = neutron[:neutron][:ml2_mechanism_drivers]
   ml2_type_drivers = neutron[:neutron][:ml2_type_drivers]
 
@@ -259,6 +257,9 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
     external_network_bridge = ""
   end
+
+  # include neutron::common_config only now, after we've installed packages
+  include_recipe "neutron::common_config"
 
   # L2 agent
   if neutron[:neutron][:use_gitrepo]


### PR DESCRIPTION
The neutron packages are installed too late and we end up with this
error:
```
[2015-04-22T15:01:23+00:00] INFO: Processing ruby_block[edit /etc/sysctl.conf for rp_filter] action create (neutron::common_agent line 26)
[2015-04-22T15:01:23+00:00] INFO: ruby_block[edit /etc/sysctl.conf for rp_filter] called
[2015-04-22T15:01:23+00:00] INFO: Processing directory[create /etc/sysctl.d for disable-rp_filter] action create (neutron::common_agent line 35)
[2015-04-22T15:01:23+00:00] INFO: Processing cookbook_file[/etc/sysctl.d/50-neutron-disable-rp_filter.conf] action create (neutron::common_agent line 41)
[2015-04-22T15:01:23+00:00] INFO: Processing bash[reload disable-rp_filter-sysctl] action nothing (neutron::common_agent line 46)
[2015-04-22T15:01:23+00:00] INFO: Processing service[ovs-usurp-config-br-public] action disable (neutron::common_agent line 224)
[2015-04-22T15:01:23+00:00] INFO: Processing file[/etc/init.d/ovs-usurp-config-br-public] action delete (neutron::common_agent line 231)
[2015-04-22T15:01:23+00:00] INFO: Processing service[ovs-usurp-config-br-fixed] action disable (neutron::common_agent line 224)
[2015-04-22T15:01:23+00:00] INFO: Processing file[/etc/init.d/ovs-usurp-config-br-fixed] action delete (neutron::common_agent line 231)
[2015-04-22T15:01:23+00:00] INFO: Processing ruby_block[Find neutron rootwrap] action create (neutron::common_config line 75)

================================================================================
Error executing action `create` on resource 'ruby_block[Find neutron rootwrap]'
================================================================================

RuntimeError
------------
Could not find neutron rootwrap binary!

Cookbook Trace:
---------------
/var/chef/cache/cookbooks/neutron/recipes/common_config.rb:86:in `block (2 levels) in from_file'

Resource Declaration:
---------------------

 75: ruby_block "Find neutron rootwrap" do
 76:   block do
 77:     found = false
 78:     ENV['PATH'].split(':').each do |p|
 79:       f = File.join(p,"neutron-rootwrap")
 80:       next unless File.executable?(f)
 81:       node.set[:neutron][:rootwrap] = f
 82:       node.save
 83:       found = true
 84:       break
 85:     end
 86:     raise("Could not find neutron rootwrap binary!") unless found
 87:   end
 88: end
 89:

Compiled Resource:
------------------

ruby_block("Find neutron rootwrap") do
  action "create"
  retries 0
  retry_delay 2
  block_name "Find neutron rootwrap"
  cookbook_name "neutron"
  recipe_name "common_config"
  block #<Proc:0x00000003ff8f90@/var/chef/cache/cookbooks/neutron/recipes/common_config.rb:76>
end
```