### PR TITLE
allow nova-access to work with ssl-keystone (bnc#895594)

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -115,7 +115,7 @@ unless nova[:nova].nil? or nova[:nova][:ssl].nil?
   nova_api_host = CrowbarHelper.get_host_for_admin_url(nova, (nova[:nova][:ha][:enabled] rescue false))
   nova_api_protocol = nova[:nova][:ssl][:enabled] ? "https" : "http"
   keystone_insecure = keystone_settings['insecure'] ? "--insecure" : ""
-  nova_insecure = nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure]
+  nova_insecure = keystone_settings['insecure'] || (nova[:nova][:ssl][:enabled] && nova[:nova][:ssl][:insecure])
 
   keystone_register "neutron config wakeup keystone" do
     protocol keystone_settings['protocol']


### PR DESCRIPTION
This is needed when keystone is deployed with SSL certs
that dont cover all internal hostnames (aka insecure),
but nova is not deployed with HTTPS,
so the insecure flag is missing there.

https://bugzilla.suse.com/show_bug.cgi?id=895594

This is very much like https://github.com/crowbar/barclamp-nova/pull/445