### PR TITLE
pass keystone admin password to neutron-ha-tool via file (bsc#922751)

### DIFF
--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -139,6 +139,7 @@ pacemaker_primitive ha_tool_primitive_name do
   agent node[:neutron][:ha][:network][:ha_tool_ra]
   params ({
     "os_auth_url"    => keystone_settings["internal_auth_url"],
+    "os_region_name" => keystone_settings["endpoint_region"],
     "os_tenant_name" => keystone_settings["admin_tenant"],
     "os_username"    => keystone_settings["admin_user"],
     "os_insecure"    => keystone_settings["insecure"] || node[:neutron][:ssl][:insecure]

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -125,13 +125,22 @@ ha_tool_primitive_name = "neutron-ha-tool"
 # right CA file as we allow Keystone's and Neutron's to use different CAs.  So
 # we just rely on the correct CA files being installed in a system wide default
 # location.
+file "/etc/neutron/os_password" do
+  owner 'root'
+  group 'root'
+  mode '0600'
+  content keystone_settings["admin_password"]
+  # Our Chef is apparently too old for this :-/
+  #sensitive true
+  action :create
+end
+
 pacemaker_primitive ha_tool_primitive_name do
   agent node[:neutron][:ha][:network][:ha_tool_ra]
   params ({
     "os_auth_url"    => keystone_settings["internal_auth_url"],
     "os_tenant_name" => keystone_settings["admin_tenant"],
     "os_username"    => keystone_settings["admin_user"],
-    "os_password"    => keystone_settings["admin_password"],
     "os_insecure"    => keystone_settings["insecure"] || node[:neutron][:ssl][:insecure]
   })
   op node[:neutron][:ha][:network][:op]


### PR DESCRIPTION
Will need backporting to tex and maybe stoney too.

Requires corresponding change in neutron-ha-tool:

https://build.suse.de/request/show/57156