### PR TITLE
Set dhcp_agents_per_network option in neutron.conf

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -120,6 +120,8 @@ if neutron[:neutron][:use_lbaas] then
   service_plugins = "#{service_plugins}, neutron.services.loadbalancer.plugin.LoadBalancerPlugin"
 end
 
+network_nodes = search_env_filtered(:node, "roles:neutron-network")
+
 template "/etc/neutron/neutron.conf" do
     cookbook "neutron"
     source "neutron.conf.erb"
@@ -150,7 +152,8 @@ template "/etc/neutron/neutron.conf" do
       :rootwrap_bin =>  node[:neutron][:rootwrap],
       :use_namespaces => true,
       :allow_overlapping_ips => neutron[:neutron][:allow_overlapping_ips],
-      :dvr_enabled => neutron[:neutron][:use_dvr]
+      :dvr_enabled => neutron[:neutron][:use_dvr],
+      :network_nodes_count => network_nodes.count
     }.merge(nova_notify))
 end
 

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -191,7 +191,7 @@ allow_overlapping_ips = False
 
 # Number of DHCP agents scheduled to host a network. This enables redundant
 # DHCP agents for configured networks.
-# dhcp_agents_per_network = 1
+dhcp_agents_per_network = <%= @network_nodes_count %>
 
 # ===========  end of items for agent scheduler extension =====
 


### PR DESCRIPTION
neutron-ha-tool replicates the dhcp only on start which is wrong an
causes new networks to be not replicated to the available dhcp-agent

this change effects that neutron keeps care about this behavior