### PR TITLE
[tex] Set dhcp_agents_per_network option (bsc#928189)

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -145,7 +145,10 @@ if neutron[:neutron][:use_lbaas] then
   service_plugins = "#{service_plugins}, neutron.services.loadbalancer.plugin.LoadBalancerPlugin"
 end
 
-network_nodes = search_env_filtered(:node, "roles:neutron-network")
+network_nodes_count = neutron[:neutron][:elements]["neutron-network"].count
+if neutron[:neutron][:elements_expanded]
+  network_nodes_count = neutron[:neutron][:elements_expanded]["neutron-network"].count
+end
 
 template "/etc/neutron/neutron.conf" do
     cookbook "neutron"
@@ -178,7 +181,7 @@ template "/etc/neutron/neutron.conf" do
       :use_namespaces => true,
       :allow_overlapping_ips => neutron[:neutron][:allow_overlapping_ips],
       :dvr_enabled => neutron[:neutron][:use_dvr],
-      :network_nodes_count => network_nodes.count
+      :network_nodes_count => network_nodes_count
     }.merge(nova_notify))
 end
 

--- a/chef/cookbooks/neutron/recipes/common_config.rb
+++ b/chef/cookbooks/neutron/recipes/common_config.rb
@@ -145,6 +145,8 @@ if neutron[:neutron][:use_lbaas] then
   service_plugins = "#{service_plugins}, neutron.services.loadbalancer.plugin.LoadBalancerPlugin"
 end
 
+network_nodes = search_env_filtered(:node, "roles:neutron-network")
+
 template "/etc/neutron/neutron.conf" do
     cookbook "neutron"
     source "neutron.conf.erb"
@@ -175,7 +177,8 @@ template "/etc/neutron/neutron.conf" do
       :rootwrap_bin =>  node[:neutron][:rootwrap],
       :use_namespaces => true,
       :allow_overlapping_ips => neutron[:neutron][:allow_overlapping_ips],
-      :dvr_enabled => neutron[:neutron][:use_dvr]
+      :dvr_enabled => neutron[:neutron][:use_dvr],
+      :network_nodes_count => network_nodes.count
     }.merge(nova_notify))
 end
 

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -191,7 +191,7 @@ allow_overlapping_ips = False
 
 # Number of DHCP agents scheduled to host a network. This enables redundant
 # DHCP agents for configured networks.
-# dhcp_agents_per_network = 1
+dhcp_agents_per_network = <%= @network_nodes_count %>
 
 # ===========  end of items for agent scheduler extension =====
 


### PR DESCRIPTION
Backport of #221

neutron-ha-tool replicates the dhcp only on start which is wrong an
causes new networks to be not replicated to the available dhcp-agent.
This change effects that neutron keeps care about this behavior.

(cherry picked from commit a674f11ab30f86d74cc7ec29bc0c1086e1598441)