### PR TITLE
Allow switching the Keystone API version

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -19,6 +19,7 @@ override[:neutron][:group]="neutron"
 
 default[:neutron][:debug] = false
 default[:neutron][:verbose] = false
+default[:neutron][:max_header_line] = 16384
 default[:neutron][:dhcp_domain] = "openstack.local"
 default[:neutron][:networking_plugin] = "ml2"
 

--- a/chef/cookbooks/neutron/recipes/network_agents_ha.rb
+++ b/chef/cookbooks/neutron/recipes/network_agents_ha.rb
@@ -117,6 +117,11 @@ pacemaker_clone agents_clone_name do
 end
 
 keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
+# FIXME: neutron-ha-tool can't do keystone v3 currently
+os_auth_url_v2 =  KeystoneHelper.versioned_service_URL(keystone_settings["protocol"],
+                                                       keystone_settings["internal_url_host"],
+                                                       keystone_settings["service_port"],
+                                                       "2.0")
 
 ha_tool_primitive_name = "neutron-ha-tool"
 
@@ -138,7 +143,7 @@ end
 pacemaker_primitive ha_tool_primitive_name do
   agent node[:neutron][:ha][:network][:ha_tool_ra]
   params ({
-    "os_auth_url"    => keystone_settings["internal_auth_url"],
+    "os_auth_url"    => os_auth_url_v2,
     "os_region_name" => keystone_settings["endpoint_region"],
     "os_tenant_name" => keystone_settings["admin_tenant"],
     "os_username"    => keystone_settings["admin_user"],

--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -56,6 +56,10 @@ neutron_args = "#{neutron_args} --os-password '#{keystone_settings['service_pass
 neutron_args = "#{neutron_args} --os-tenant-name '#{keystone_settings['service_tenant']}'"
 neutron_args = "#{neutron_args} --os-auth-url '#{keystone_settings['internal_auth_url']}'"
 neutron_args = "#{neutron_args} --os-region-name '#{keystone_settings['endpoint_region']}'"
+if keystone_settings['api_version'] != "2.0"
+  neutron_args = "#{neutron_args} --os-user-domain-name Default"
+  neutron_args = "#{neutron_args} --os-project-domain-name Default"
+end
 neutron_args = "#{neutron_args} --endpoint-type internalURL"
 neutron_args = "#{neutron_args} --insecure" if ssl_insecure
 neutron_cmd = "neutron #{neutron_args}"

--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -7,7 +7,10 @@ debug = <%= @debug ? "True" : "False" %>
 
 # The Neutron user information for accessing the Neutron API.
 # auth_url = http://localhost:5000/v2.0
-auth_url = <%= @keystone_settings['internal_auth_url'] %>
+auth_url = <%= KeystoneHelper.versioned_service_URL(@keystone_settings["protocol"],
+                                                    @keystone_settings["internal_url_host"],
+                                                    @keystone_settings["service_port"],
+                                                    "2.0") %>
 # auth_region = RegionOne
 auth_region = <%= @auth_region %>
 # Turn off verification of the certificate for ssl

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -301,7 +301,10 @@ nova_admin_password = <%= @nova_admin_password if @nova_admin_password %>
 
 # Authorization URL for connection to nova in admin context.
 # nova_admin_auth_url =
-nova_admin_auth_url = <%= @keystone_settings['internal_auth_url'] %>
+nova_admin_auth_url = <%= KeystoneHelper.versioned_service_URL(@keystone_settings["protocol"],
+                                    @keystone_settings["internal_url_host"],
+                                    @keystone_settings["service_port"],
+                                    "2.0") %>
 
 # CA file for novaclient to verify server certificates
 # nova_ca_certificates_file =

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -245,7 +245,7 @@ rpc_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 # backlog = 4096
 
 # Max header line to accommodate large tokens
-# max_header_line = 16384
+max_header_line = <%= node[:neutron][:max_header_line] %>
 
 # Enable SSL on the API server
 # use_ssl = False

--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -626,6 +626,7 @@ auth_uri = <%= @keystone_settings['public_auth_url'] %>
 # (string value)
 identity_uri = <%= @keystone_settings['admin_auth_url'] %>
 
+auth_version = <%= @keystone_settings['api_version_for_middleware'] %>
 admin_tenant_name = <%= @keystone_settings['service_tenant'] %>
 admin_user = <%= @keystone_settings['service_user'] %>
 admin_password = <%= @keystone_settings['service_password'] %>

--- a/chef/data_bags/crowbar/bc-template-neutron.json
+++ b/chef/data_bags/crowbar/bc-template-neutron.json
@@ -6,6 +6,7 @@
       "service_user": "neutron",
       "rabbitmq_instance": "none",
       "keystone_instance": "none",
+      "max_header_line": 16384,
       "debug": false,
       "verbose": true,
       "dhcp_domain": "openstack.local",
@@ -66,7 +67,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 40,
+      "schema-revision": 41,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-neutron.schema
+++ b/chef/data_bags/crowbar/bc-template-neutron.schema
@@ -9,6 +9,7 @@
              "mapping": {
                     "verbose": { "type": "bool", "required": true },
                     "debug": { "type": "bool", "required": true },
+                    "max_header_line": { "type": "int", "required": true },
                     "service_user": { "type": "str", "required": true },
                     "service_password": { "type": "str" },
                     "rabbitmq_instance": { "type": "str", "required": true },

--- a/chef/data_bags/crowbar/migrate/041_add_max_header_line.rb
+++ b/chef/data_bags/crowbar/migrate/041_add_max_header_line.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['max_header_line'] = 16384
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('max_header_line')
+  return a, d
+end


### PR DESCRIPTION
Depends on: https://github.com/crowbar/barclamp-neutron/pull/197 and https://github.com/crowbar/barclamp-keystone/pull/280

Note there are currently a few places where the keystone v3 api is not supported by neutron (mostly neutron-ha-tool, still need to check what's breaking v3 for the metadata agent). In those place the v2 URL is still used for now.