### PR TITLE
Allocate SDN IP for NSX nodes, (bnc#934688)

### DIFF
--- a/crowbar_framework/app/models/neutron_service.rb
+++ b/crowbar_framework/app/models/neutron_service.rb
@@ -296,6 +296,8 @@ class NeutronService < PacemakerServiceObject
             node.save
           end
         end
+      elsif role.default_attributes["neutron"]["networking_plugin"] == "vmware"
+        net_svc.allocate_ip "default","os_sdn","host", n
       end
     end
     @logger.debug("Neutron apply_role_pre_chef_call: leaving")


### PR DESCRIPTION

It is fixing https://bugzilla.suse.com/show_bug.cgi?id=934688

```
================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/neutron/recipes/l3.rb
================================================================================

NoMethodError
-------------
undefined method `first' for nil:NilClass

Cookbook Trace:
---------------
/var/chef/cache/cookbooks/neutron/recipes/vmware_support.rb:96:in `from_file'
/var/chef/cache/cookbooks/neutron/recipes/common_agent.rb:196:in `from_file'
/var/chef/cache/cookbooks/neutron/recipes/l3.rb:17:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/neutron/recipes/vmware_support.rb:

 89:    command "ovs-vsctl br-set-external-id br1 bridge-id br1"
 90:  end
 91:
 92:  execute "set_bridge_config_br1" do
 93:    command "ovs-vsctl set Bridge br1 fail_mode=standalone"
 94:  end
 95:
 96>> bound_if = node[:crowbar_wall][:network][:nets][:os_sdn].first
```