### PR TITLE
Enable setting multiple external networks

### DIFF
--- a/chef/cookbooks/neutron/attributes/default.rb
+++ b/chef/cookbooks/neutron/attributes/default.rb
@@ -22,6 +22,7 @@ default[:neutron][:verbose] = false
 default[:neutron][:max_header_line] = 16384
 default[:neutron][:dhcp_domain] = "openstack.local"
 default[:neutron][:networking_plugin] = "ml2"
+default[:neutron][:additional_external_networks] = []
 
 default[:neutron][:db][:database] = "neutron"
 default[:neutron][:db][:user] = "neutron"

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -189,7 +189,7 @@ else
   # Note: As moving between network plugins is currently not supported by this
   #       cookbook this code is mostly just sitting here and waiting for the
   #       plugin switching support to be implemented.
-  bridges = ["br-public", "br_fixed"]
+  bridges = ["br-public", "br-fixed"]
   neutron[:neutron][:additional_external_networks].each do |net|
     bridges << "br-#{net}"
   end
@@ -234,7 +234,7 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     neutron_agent = node[:neutron][:platform][:lb_agent_name]
     agent_config_path = "/etc/neutron/plugins/linuxbridge/linuxbridge_conf.ini"
     interface_driver = "neutron.agent.linux.interface.BridgeInterfaceDriver"
-    physnet = node[:crowbar_wall][:network][:nets][:nova_fixed].first rescue nil
+    physnet = node[:crowbar_wall][:network][:nets][:nova_fixed].first
     interface_mappings = "physnet1:" + physnet
     if multiple_external_networks
       neutron[:neutron][:additional_external_networks].each do |net|

--- a/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/l3_agent.ini.erb
@@ -50,7 +50,7 @@ handle_internal_only_routers = <%= @handle_internal_only_routers %>
 # empty value for the linux bridge. when this parameter is set, each L3 agent
 # can be associated with no more than one external network.
 # external_network_bridge = br-ex
-external_network_bridge = <%= @external_network_bridge %>
+external_network_bridge = 
 
 # TCP Port used by Neutron metadata server
 # metadata_port = 9697

--- a/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
@@ -34,7 +34,7 @@
 #
 # physical_interface_mappings =
 # Example: physical_interface_mappings = physnet1:eth1
-physical_interface_mappings = physnet1:<%=@physnet%>
+physical_interface_mappings = <%=@interface_mappings%>
 
 [vxlan]
 # (BoolOpt) enable VXLAN on the agent

--- a/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
@@ -34,7 +34,7 @@
 #
 # physical_interface_mappings =
 # Example: physical_interface_mappings = physnet1:eth1
-physical_interface_mappings = <%=@interface_mappings%>
+physical_interface_mappings = <%= @interface_mappings %>
 
 [vxlan]
 # (BoolOpt) enable VXLAN on the agent

--- a/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
@@ -93,9 +93,7 @@ local_ip = <%= node.address("os_sdn").addr %>
 #
 # bridge_mappings =
 # Example: bridge_mappings = physnet1:br-eth1
-<% if @ml2_type_drivers.include?("vlan") -%>
-bridge_mappings = physnet1:br-fixed
-<% end -%>
+bridge_mappings = <%= @bridge_mappings %>
 
 # (BoolOpt) Use veths instead of patch ports to interconnect the integration
 # bridge to physical networks. Support kernel without ovs patch port support

--- a/chef/data_bags/crowbar/bc-template-neutron.json
+++ b/chef/data_bags/crowbar/bc-template-neutron.json
@@ -13,6 +13,7 @@
       "use_lbaas": true,
       "use_l2pop": true,
       "use_dvr": false,
+      "additional_external_networks": [],
       "networking_plugin": "ml2",
       "ml2_mechanism_drivers": ["openvswitch"],
       "ml2_type_drivers": ["gre"],
@@ -67,7 +68,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 41,
+      "schema-revision": 42,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-neutron.schema
+++ b/chef/data_bags/crowbar/bc-template-neutron.schema
@@ -18,6 +18,7 @@
                     "use_lbaas": { "type": "bool", "required": true },
                     "use_l2pop": { "type": "bool", "required": true },
                     "use_dvr": { "type": "bool", "required": true },
+                    "additional_external_networks": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "networking_plugin": { "type": "str", "required": true },
                     "ml2_mechanism_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },
                     "ml2_type_drivers": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ] },

--- a/chef/data_bags/crowbar/migrate/neutron/042_additional_external_networks.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/042_additional_external_networks.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['additional_external_networks'] = ta['additional_external_networks']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a.delete('additional_external_networks')
+  return a, d
+end


### PR DESCRIPTION
Enable multiple external network for Neutron.
Some manual steps are still needed and will be documented in the
official documentation.