### PR TITLE
Set cookbook name in metadata

### DIFF
--- a/chef/cookbooks/neutron/metadata.rb
+++ b/chef/cookbooks/neutron/metadata.rb
@@ -1,5 +1,6 @@
-maintainer       "Dell, Inc."
-maintainer_email "crowbar@Dell.com"
+name             "neutron"
+maintainer       "Crowbar project"
+maintainer_email "crowbar@googlegroups.com"
 license          "Apache 2.0 License, Copyright (c) 2011 Dell Inc. - http://www.apache.org/licenses/LICENSE-2.0"
 description      "Openstack Neutron server deployment recipes."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))


### PR DESCRIPTION
Needed if the cookbook is used without the crowbar framework. I.e. using
the cookbook as berkshelf dependency.
Also update maintainer email address.