### PR TITLE
Do not run multiple api/rpc processes

### DIFF
--- a/chef/cookbooks/neutron/templates/default/neutron.conf.erb
+++ b/chef/cookbooks/neutron/templates/default/neutron.conf.erb
@@ -216,11 +216,7 @@ dhcp_agents_per_network = <%= @network_nodes_count %>
 # worker thread in the current process.  Greater than 0 launches that number of
 # child processes as workers.  The parent process manages them.
 # api_workers = 0
-# This is workaround for lp#1354226
-# https://bugs.launchpad.net/neutron/+bug/1354226
-<% unless @core_plugin == "vmware" -%>
-api_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
-<% end -%>
+api_workers = 0
 
 # Number of separate RPC worker processes to spawn.  The default, 0, runs the
 # worker thread in the current process.  Greater than 0 launches that number of
@@ -228,11 +224,7 @@ api_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
 # This feature is experimental until issues are addressed and testing has been
 # enabled for various plugins for compatibility.
 # rpc_workers = 0
-# This is workaround for lp#1354226
-# https://bugs.launchpad.net/neutron/+bug/1354226
-<% unless @core_plugin == "vmware" -%>
-rpc_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
-<% end -%>
+rpc_workers = 0
 
 # Sets the value of TCP_KEEPIDLE in seconds to use for each server socket when
 # starting API server. Not supported on OS X.


### PR DESCRIPTION
This requires excessive amount of memory and causes the mkcloud
runs to fail randomly. In addition this is marked as experimental
upstream and currently not well tested.