### PR TITLE
Disable multiple external network support

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -89,7 +89,10 @@ if neutron[:neutron][:networking_plugin] == 'vmware' or
   end
 end
 
-multiple_external_networks = !neutron[:neutron][:additional_external_networks].empty? && node.roles.include?("neutron-network")
+# NOTE(toabctl): Disable multiple external networks support for now
+# TODO: reenable!
+# multiple_external_networks = !neutron[:neutron][:additional_external_networks].empty? && node.roles.include?("neutron-network")
+
 # openvswitch configuration specific to ML2
 if neutron[:neutron][:networking_plugin] == 'ml2' and
    neutron[:neutron][:ml2_mechanism_drivers].include?("openvswitch")


### PR DESCRIPTION
There seems to be a problem and we have revert-external-network.patch
in our rpm package to revert the support.
So multiple external network support needs some rework and we disable
it for now.