### PR TITLE
Disable multiple external networks fix

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -92,6 +92,7 @@ end
 # NOTE(toabctl): Disable multiple external networks support for now
 # TODO: reenable!
 # multiple_external_networks = !neutron[:neutron][:additional_external_networks].empty? && node.roles.include?("neutron-network")
+multiple_external_networks = false
 
 # openvswitch configuration specific to ML2
 if neutron[:neutron][:networking_plugin] == 'ml2' and


### PR DESCRIPTION
Commit 18e8e32ab23ce0c112bc281594718f8d6a987cb2 disabled
multiple extenal networks support but the commit is incomplete.
The code raises a "NameError" now because the variable
"multiple_external_networks" is not defined.