### PR TITLE
Be conservative with starting metadata agents

### DIFF
--- a/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/metadata_agent.ini.erb
@@ -61,7 +61,7 @@ metadata_proxy_shared_secret = <%= @metadata_proxy_shared_secret %>
 # Number of separate worker processes for metadata server. Defaults to
 # half the number of CPU cores
 # metadata_workers =
-metadata_workers = <%= [node["cpu"]["total"], 2, 4].sort[1] %>
+metadata_workers = <%= [node["cpu"]["total"]/2, 4].min %>
 
 # Number of backlog requests to configure the metadata server socket with
 # metadata_backlog = 4096


### PR DESCRIPTION
The default behavior of starting #cpu/2 "extra" agents makes
more sense, but still give it a top of 4 metadata agents.