### PR TITLE
Install fwaas packages on the neutron-network role node

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -319,7 +319,9 @@ if neutron[:neutron][:networking_plugin] == "ml2"
 
   # L3 agent
   if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
-    package node[:neutron][:platform][:l3_agent_pkg]
+    pkgs = [node[:neutron][:platform][:l3_agent_pkg]] + \
+           node[:neutron][:platform][:pkgs_fwaas]
+    pkgs.each { |p| package p }
 
     template "/etc/neutron/l3_agent.ini" do
       source "l3_agent.ini.erb"


### PR DESCRIPTION
The l3-agent needs the fwaas package. Otherwise you get:

    ERROR neutron.services.firewall.agents.l3reference.firewall_l3_agent \
          FWaaS plugin is configured in the server side,
          but FWaaS is disabled in L3-agent.

and the l3 agent service can not start.