### PR TITLE
Revert "Disable multiple external network support"

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -89,11 +89,7 @@ if neutron[:neutron][:networking_plugin] == 'vmware' or
   end
 end
 
-# NOTE(toabctl): Disable multiple external networks support for now
-# TODO: reenable!
-# multiple_external_networks = !neutron[:neutron][:additional_external_networks].empty? && node.roles.include?("neutron-network")
-multiple_external_networks = false
-
+multiple_external_networks = !neutron[:neutron][:additional_external_networks].empty? && node.roles.include?("neutron-network")
 # openvswitch configuration specific to ML2
 if neutron[:neutron][:networking_plugin] == 'ml2' and
    neutron[:neutron][:ml2_mechanism_drivers].include?("openvswitch")


### PR DESCRIPTION
With the underlying regression fixed, we can reenable the
support for multiple external networks.

This reverts commit 18e8e32ab23ce0c112bc281594718f8d6a987cb2.