### PR TITLE
Create "floating" network as "flat" provider network (bsc#946882)

### DIFF
--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -77,20 +77,14 @@ networking_plugin = node[:neutron][:networking_plugin]
 ml2_type_drivers_default_provider_network = node[:neutron][:ml2_type_drivers_default_provider_network]
 case networking_plugin
 when 'ml2'
+  floating_network_type = "--provider:network_type flat --provider:physical_network floating"
   case ml2_type_drivers_default_provider_network
   when 'vlan'
     fixed_network_type = "--provider:network_type vlan --provider:segmentation_id #{fixed_net["vlan"]} --provider:physical_network physnet1"
-    if node[:network][:networks][:nova_floating][:use_vlan]
-      floating_network_type = "--provider:network_type vlan --provider:segmentation_id #{floating_net["vlan"]} --provider:physical_network physnet1"
-    else
-      floating_network_type = "--provider:network_type flat --provider:physical_network physnet1"
-    end
   when 'gre'
     fixed_network_type = "--provider:network_type gre --provider:segmentation_id 1"
-    floating_network_type = "--provider:network_type gre --provider:segmentation_id 2"
   when 'vxlan'
     fixed_network_type = "--provider:network_type vxlan --provider:segmentation_id #{vni_start}"
-    floating_network_type = "--provider:network_type vxlan --provider:segmentation_id #{vni_start + 1}"
   else
     Chef::Log.error("default provider network ml2 type driver '#{ml2_type_drivers_default_provider_network}' invalid for creating provider networks")
   end

--- a/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/linuxbridge_conf.ini.erb
@@ -34,7 +34,7 @@
 #
 # physical_interface_mappings =
 # Example: physical_interface_mappings = physnet1:eth1
-physical_interface_mappings = physnet1:<%=@physnet%>
+physical_interface_mappings = <%= @interface_mappings %>
 
 [vxlan]
 # (BoolOpt) enable VXLAN on the agent

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -37,6 +37,7 @@ mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 # flat_networks =
 # Example:flat_networks = physnet1,physnet2
 # Example:flat_networks = *
+flat_networks = floating
 
 [ml2_type_vlan]
 # (ListOpt) List of <physical_network>[:<vlan_min>:<vlan_max>] tuples


### PR DESCRIPTION
This should work regardless of the mechanism driver that is used  (openvswitch
or linuxbridge) as we have the ml2 type driver "flat" enabled unconditionally.
This is also in line with the behaviour of devstack.

For linuxbridge setups this commit also adjust the interface mappings for
external networks to use the VLAN interface instead for the underlying physical
interface. That's required for "flat" networks.

We also make sure to specify the right "--provider:physical_network" parameter
for the floating network. Otherwise the floating network might endup on the
wrong phyiscal interfaces in deployments that use different network conduits
for "nova_floating" and "nova_fixed".
