### PR TITLE
Fix migration of neutron-l3 to neutron-network in HA case (bsc#954735)

### DIFF
--- a/chef/data_bags/crowbar/bc-template-neutron.json
+++ b/chef/data_bags/crowbar/bc-template-neutron.json
@@ -121,7 +121,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 29,
+      "schema-revision": 30,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/migrate/neutron/030_fix_rename_l3_role.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/030_fix_rename_l3_role.rb
@@ -1,0 +1,17 @@
+def upgrade ta, td, a, d
+  if d.fetch('elements_expanded', {}).has_key? 'neutron-l3'
+    d['elements_expanded']['neutron-network'] = d['elements_expanded']['neutron-l3']
+    d['elements_expanded'].delete('neutron-l3')
+  end
+
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  if d.fetch('elements_expanded', {}).has_key? 'neutron-network'
+    d['elements_expanded']['neutron-l3'] = d['elements_expanded']['neutron-network']
+    d['elements_expanded'].delete('neutron-network')
+  end
+
+  return a, d
+end


### PR DESCRIPTION
We also need to migrate the elements_expanded attribute.

https://bugzilla.suse.com/show_bug.cgi?id=954735
