### PR TITLE
Do not rely on notification to enable ovs-usurp-config scripts

### DIFF
--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -211,8 +211,9 @@ if neutron[:neutron][:networking_plugin] == 'ml2' and
     end
     service "ovs-usurp-config-#{name}" do
       # Don't start it here. It only needs to be executed during boot.
-      action [:nothing]
-      subscribes :enable, resources("template[/etc/init.d/ovs-usurp-config-#{name}]")
+      action [:enable]
+      # see comment in template above
+      not_if { addresses.empty? and routes.empty? }
     end
   end
 else


### PR DESCRIPTION
With a notification, if chef-client crashes before the end, the script
will never be enabled. Just always enable it, there's no reason why we
would want to not do this in the case where we have the script.
