### PR TITLE
Fix interface mappings when floating is not on a VLAN (bsc#955811)

### DIFF
--- a/chef/cookbooks/neutron/libraries/helpers.rb
+++ b/chef/cookbooks/neutron/libraries/helpers.rb
@@ -1,0 +1,66 @@
+module NeutronHelper
+  # Find out how many (and which) physnets we need to define in neutron.
+  # Input is the list of external_networks that we'll have. Returns a hash where
+  # external_network -> physnet pairs
+  def self.get_neutron_physnets(node, external_networks)
+    # This assumes that "nova_fixed" will always be on the phynet called
+    # "physnet1" in neutron
+    # Also we don't allow to put 2 external networks on the same neutron
+    # physnet.
+
+    networks = Hash.new
+    interfaces_used = Hash.new
+    external_networks.each do |net|
+      networks[net] = node["network"]["networks"][net].to_hash
+      networks[net]["interface"] =
+        BarclampLibrary::Barclamp::Inventory.lookup_interface_info(
+          node, networks[net]["conduit"]).first
+      networks[net]["interface"] += ".#{networks[net]["vlan"]}" if networks[net]["use_vlan"]
+
+      if interfaces_used[networks[net]["interface"]]
+        Chef::Log.error(
+          "Networks '#{net}' and '#{interfaces_used[networks[net]["interface"]]}' " \
+          "will use the same physical interface (#{networks[net]["interface"]}) " \
+          "on node #{node.name}.")
+        raise "Two or more external networks will end up on the same physical interface."
+      else
+        interfaces_used[networks[net]["interface"]] = net
+      end
+    end
+
+    # Now check if any of the external network will share the physical interface
+    # with "nova_fixed".
+    fixed_conduit = node[:network][:networks][:nova_fixed][:conduit]
+    fixed_interface = BarclampLibrary::Barclamp::Inventory.lookup_interface_info(
+      node, fixed_conduit)[0]
+    fixed_physnet = "physnet1"
+
+    physmap = Hash.new
+    networks.each do |net, values|
+      if values["interface"] == fixed_interface
+        physmap[net] = fixed_physnet
+      elsif net == "nova_floating"
+        physmap[net] = "floating"
+      else
+        physmap[net] = net
+      end
+    end
+    physmap
+  end
+
+  # Returns the node object referring the first network-node
+  def self.get_network_node_from_neutron_attributes(node)
+    if node.roles.include?("neutron-network")
+      return node
+    else
+      network_node_name = ""
+      if node[:neutron][:ha][:network][:enabled]
+        # network role is deployed in an HA mode, pick the first node
+        network_node_name = node[:neutron][:elements_expanded][:'neutron-network'][0]
+      else
+        network_node_name = node[:neutron][:elements][:'neutron-network'][0]
+      end
+      Chef::Node.load(network_node_name)
+    end
+  end
+end

--- a/chef/cookbooks/neutron/recipes/common_agent.rb
+++ b/chef/cookbooks/neutron/recipes/common_agent.rb
@@ -259,8 +259,14 @@ if neutron[:neutron][:networking_plugin] == "ml2"
     physnet = node[:crowbar_wall][:network][:nets][:nova_fixed].first
     interface_mappings = "physnet1:" + physnet
     if neutron[:neutron][:use_dvr] || node.roles.include?("neutron-network")
-      floatingphys = node[:crowbar_wall][:network][:nets][:nova_floating].last
-      interface_mappings += ", floating:" + floatingphys
+      external_networks = ["nova_floating"]
+      ext_physnet_map = NeutronHelper.get_neutron_physnets(node, external_networks)
+      external_networks.each do |net|
+        ext_iface = node[:crowbar_wall][:network][:nets][net].last
+        next if ext_physnet_map[net] == "physnet1"
+        mapping = ", " + ext_physnet_map[net] + ":" + ext_iface
+        interface_mappings += mapping
+      end
     end
   end
 

--- a/chef/cookbooks/neutron/recipes/post_install_conf.rb
+++ b/chef/cookbooks/neutron/recipes/post_install_conf.rb
@@ -77,7 +77,11 @@ networking_plugin = node[:neutron][:networking_plugin]
 ml2_type_drivers_default_provider_network = node[:neutron][:ml2_type_drivers_default_provider_network]
 case networking_plugin
 when 'ml2'
-  floating_network_type = "--provider:network_type flat --provider:physical_network floating"
+  # find the network node, to figure out the right "physnet" parameter
+  network_node = NeutronHelper.get_network_node_from_neutron_attributes(node)
+  ext_physnet_map = NeutronHelper.get_neutron_physnets(network_node, ["nova_floating"])
+  floating_network_type = "--provider:network_type flat " \
+    "--provider:physical_network #{ext_physnet_map["nova_floating"]}"
   case ml2_type_drivers_default_provider_network
   when 'vlan'
     fixed_network_type = "--provider:network_type vlan --provider:segmentation_id #{fixed_net["vlan"]} --provider:physical_network physnet1"

--- a/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ml2_conf.ini.erb
@@ -37,7 +37,7 @@ mechanism_drivers = <%= @ml2_mechanism_drivers.join(",") %>
 # flat_networks =
 # Example:flat_networks = physnet1,physnet2
 # Example:flat_networks = *
-flat_networks = floating
+flat_networks = <%= @external_networks.join(",") %>
 
 [ml2_type_vlan]
 # (ListOpt) List of <physical_network>[:<vlan_min>:<vlan_max>] tuples

--- a/chef/data_bags/crowbar/bc-template-neutron.json
+++ b/chef/data_bags/crowbar/bc-template-neutron.json
@@ -121,7 +121,7 @@
     "neutron": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 30,
+      "schema-revision": 31,
       "element_states": {
         "neutron-server": [ "readying", "ready", "applying" ],
         "neutron-network": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/migrate/neutron/031_enable_floating_interface.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/031_enable_floating_interface.rb
@@ -1,0 +1,16 @@
+def upgrade(ta, td, a, d)
+  # This migration does not update anything on the proposals/roles but
+  # it tries to enable the nova_floating network on all nodes that need
+  # it.
+  nodes = NodeObject.find("roles:neutron-network")
+  # When using DVR we need to update the compute nodes as well
+  if nodes.first["neutron"]["use_dvr"]
+    nodes << NodeObject.find("roles:nova-multi-compute-* NOT roles:nova-multi-compute-vmware")
+    nodes.flatten!
+  end
+  net_svc = NetworkService.new Rails.logger
+  nodes.each do |n|
+    net_svc.enable_interface "default", "nova_floating", n.name
+  end
+  return a, d
+end


### PR DESCRIPTION
If "nova_floating" as "use_vlan" turned of and is configured to use the same
conduit as "nova_fixed" they need to be on the same "physnet" in neutron. Try
to find those cases, write the interface_mapping accordingly and adjust the
"net-create" parameters for that.

Partiall fix for: https://bugzilla.suse.com/show_bug.cgi?id=955811

(cherry picked from commit fb1cea50ca2467e8a3738fac201d74ead38053f9 in
crowbar-openstack)
