### PR TITLE
Fix bridge_mapping for openvswitch setups (bsc#967009)

### DIFF
--- a/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
+++ b/chef/cookbooks/neutron/templates/default/ovs_neutron_plugin.ini.erb
@@ -93,9 +93,7 @@ local_ip = <%= node.address("os_sdn").addr %>
 #
 # bridge_mappings =
 # Example: bridge_mappings = physnet1:br-eth1
-<% if @ml2_type_drivers.include?("vlan") -%>
-bridge_mappings = physnet1:br-fixed
-<% end -%>
+bridge_mappings = <%= @bridge_mappings %>
 
 # (BoolOpt) Use veths instead of patch ports to interconnect the integration
 # bridge to physical networks. Support kernel without ovs patch port support


### PR DESCRIPTION
We're creating the floating network as a "flat" provider network therefore we
need to create the correct bridge_mappings on the network node for it.
(https://bugzilla.suse.com/show_bug.cgi?id=967009)
