### PR TITLE
Fix database attributes of the floating network and its router port (…

### DIFF
--- a/chef/cookbooks/neutron/files/default/crowbar-fix-floating-provider-attributes
+++ b/chef/cookbooks/neutron/files/default/crowbar-fix-floating-provider-attributes
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+import sqlalchemy
+import sys
+from oslo_config import cfg
+
+_cli_opts = [
+    cfg.StrOpt('network',
+               required=True,
+               help='name of the network to update'),
+    cfg.StrOpt('tenant_id',
+               required=True,
+               help='tenant_id of the network to update'),
+    cfg.StrOpt('type',
+               required=True,
+               help='new network type'),
+    cfg.StrOpt('segmentation_id',
+               required=True,
+               help='new segmentation_id'),
+    cfg.StrOpt('physnet',
+               required=True,
+               help='new physnet'),
+]
+
+_db_opts = [
+    cfg.StrOpt('connection',
+               deprecated_name='sql_connection',
+               default='',
+               secret=True,
+               help='URL to database'),
+]
+
+CONF = cfg.ConfigOpts()
+CONF.register_cli_opts(_db_opts, 'database')
+CONF.register_cli_opts(_cli_opts)
+CONF(project='neutron')
+
+db_uri = CONF.database.connection
+
+network = CONF.network
+tenant_id = CONF.tenant_id
+network_type = CONF.type
+segmentation_id = CONF.segmentation_id
+physnet = CONF.physnet
+
+db = sqlalchemy.create_engine(db_uri)
+try:
+    connection = db.connect()
+except sqlalchemy.exc.SQLAlchemyError as e:
+    print >>sys.stderr, 'Cannot connect to database: %s' % e
+    sys.exit(1)
+
+ret = connection.execute(
+    "UPDATE ml2_network_segments SET "
+    "network_type=%s, "
+    "segmentation_id=%s, "
+    "physical_network=%s "
+    "FROM networks WHERE "
+    "networks.name=%s AND "
+    "ml2_network_segments.network_id=networks.id AND "
+    "networks.tenant_id=%s;",
+    [network_type, segmentation_id, physnet, network, tenant_id])

--- a/chef/cookbooks/neutron/files/default/crowbar-fix-router-port-binding
+++ b/chef/cookbooks/neutron/files/default/crowbar-fix-router-port-binding
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+import sqlalchemy
+import sys
+from oslo_config import cfg
+
+_cli_opts = [
+    cfg.StrOpt('router',
+               required=True,
+               help='name of the network to update'),
+]
+
+_db_opts = [
+    cfg.StrOpt('connection',
+               deprecated_name='sql_connection',
+               default='',
+               secret=True,
+               help='URL to database'),
+]
+
+CONF = cfg.ConfigOpts()
+CONF.register_cli_opts(_db_opts, 'database')
+CONF.register_cli_opts(_cli_opts)
+CONF(project='neutron')
+
+db_uri = CONF.database.connection
+
+router = CONF.router
+
+db = sqlalchemy.create_engine(db_uri)
+try:
+    connection = db.connect()
+except sqlalchemy.exc.SQLAlchemyError as e:
+    print >>sys.stderr, 'Cannot connect to database: %s' % e
+    sys.exit(1)
+
+ret = connection.execute(
+    "UPDATE ml2_port_bindings set vif_type='unbound' "
+    "FROM routers,ports "
+    "WHERE ml2_port_bindings.vif_type='binding_failed' "
+    "AND routers.name=%s "
+    "AND routers.id=ports.device_id "
+    "AND ports.device_owner='network:router_gateway' "
+    "AND ports.id=ml2_port_bindings.port_id;", router)


### PR DESCRIPTION
…bsc#967009)

Because of several bugs (at least bsc#946882 and bsc#955811) we have setups
where the floating network was created with the wrong provider network
settings. While this somehow continued to work and got unnoticed it will
create problems on systems upgrading from juno to liberty. This fix tries to
to re-adjust the attributes directly neutron database to their correct values
to avoid problems during the upgrade.

https://bugzilla.suse.com/show_bug.cgi?id=967009
