### PR TITLE
Fix 031_enable_floating_interface migration (bsc#967858)

### DIFF
--- a/chef/data_bags/crowbar/migrate/neutron/031_enable_floating_interface.rb
+++ b/chef/data_bags/crowbar/migrate/neutron/031_enable_floating_interface.rb
@@ -2,7 +2,7 @@ def upgrade(ta, td, a, d)
   # This migration does not update anything on the proposals/roles but
   # it tries to enable the nova_floating network on all nodes that need
   # it.
-  nodes = NodeObject.find("roles:neutron-network")
+  nodes = NodeObject.find("roles:neutron-network OR roles:neutron-l3")
   # When using DVR we need to update the compute nodes as well
   if nodes.first["neutron"]["use_dvr"]
     nodes << NodeObject.find("roles:nova-multi-compute-* NOT roles:nova-multi-compute-vmware")


### PR DESCRIPTION
When runnign the migrations 030_fix_rename_l3_role.rb and
031_enable_floating_interface.rb directly after each other (no chef-client run
on the clients inbetween) the latter migration will fail because the search for
the new "neutron-network" role does not return any nodes. To fix that, search
the network node by the new and the old names of the role.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=967858
