### PR TITLE
Fix physnet mapping for non-vlan setups (bsc#969877)

### DIFF
--- a/chef/cookbooks/neutron/libraries/helpers.rb
+++ b/chef/cookbooks/neutron/libraries/helpers.rb
@@ -29,11 +29,15 @@ module NeutronHelper
     end
 
     # Now check if any of the external network will share the physical interface
-    # with "nova_fixed".
-    fixed_conduit = node[:network][:networks][:nova_fixed][:conduit]
-    fixed_interface = BarclampLibrary::Barclamp::Inventory.lookup_interface_info(
-      node, fixed_conduit)[0]
-    fixed_physnet = "physnet1"
+    # with "nova_fixed" if the node has "nova_fixed" enabled.
+    fixed_interface = ""
+    fixed_physnet = ""
+    if node[:crowbar_wall][:network][:nets][:nova_fixed]
+      fixed_conduit = node[:network][:networks][:nova_fixed][:conduit]
+      fixed_interface = BarclampLibrary::Barclamp::Inventory.lookup_interface_info(
+        node, fixed_conduit)[0]
+      fixed_physnet = "physnet1"
+    end
 
     physmap = Hash.new
     networks.each do |net, values|


### PR DESCRIPTION
The neutron cookbook created an inconsistent physnet configuration for
ml2_conf.ini and openvswitch_agent.ini for setups that didn't need the
"nova_fixed" interface enabled (i.e. no "vlan" type driver) and where
"use_vlan" was disabled for the "nova_floating" network.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=969877
(cherry picked from commit 4dfb6729816dfe2ce5bd26088947d6732f5b2cea)
